### PR TITLE
fix(web): sanitize auth redirect query parameter

### DIFF
--- a/apps/web/src/components/sign-in-form.tsx
+++ b/apps/web/src/components/sign-in-form.tsx
@@ -8,7 +8,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import z from "zod";
 import { authClient } from "@/lib/auth-client";
-import { cn } from "@/lib/utils";
+import { cn, toSafeRedirectPath } from "@/lib/utils";
 import Loader from "./loader";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
@@ -31,7 +31,7 @@ export default function SignInForm({
 } & React.ComponentProps<"div">) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const redirectTo = searchParams.get("redirect") || "/";
+  const redirectTo = toSafeRedirectPath(searchParams.get("redirect"), "/");
   const { isPending, data: session } = authClient.useSession();
   const [show2FA, setShow2FA] = useState(false);
   const [twoFactorEmail, setTwoFactorEmail] = useState("");

--- a/apps/web/src/components/sign-up-form.tsx
+++ b/apps/web/src/components/sign-up-form.tsx
@@ -8,7 +8,7 @@ import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import z from "zod";
 import { authClient } from "@/lib/auth-client";
-import { cn } from "@/lib/utils";
+import { cn, toSafeRedirectPath } from "@/lib/utils";
 import Loader from "./loader";
 import { Button } from "./ui/button";
 import {
@@ -30,7 +30,7 @@ export default function SignUpForm({
 } & React.ComponentProps<"div">) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const redirectTo = searchParams.get("redirect");
+  const redirectTo = toSafeRedirectPath(searchParams.get("redirect"), "");
   const plan = searchParams.get("plan");
   const interval = searchParams.get("interval") || "monthly";
   const { isPending, data: session } = authClient.useSession();
@@ -41,8 +41,8 @@ export default function SignUpForm({
   const isAuthInProgress = isRedirecting || isGoogleLoading || isGitHubLoading;
 
   const isSpecialRedirect =
-    redirectTo?.startsWith("/invitations/") ||
-    redirectTo?.startsWith("/device");
+    redirectTo.startsWith("/invitations/") ||
+    redirectTo.startsWith("/device");
 
   // Compute callback URL for OAuth - use special redirect or onboarding
   const callbackUrl = useMemo(() => {

--- a/apps/web/src/lib/__tests__/utils-redirect.test.ts
+++ b/apps/web/src/lib/__tests__/utils-redirect.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { toSafeRedirectPath } from "../utils";
+
+describe("toSafeRedirectPath", () => {
+  it("returns fallback for null, undefined, and empty values", () => {
+    expect(toSafeRedirectPath(null)).toBe("/");
+    expect(toSafeRedirectPath(undefined)).toBe("/");
+    expect(toSafeRedirectPath("")).toBe("/");
+    expect(toSafeRedirectPath("   ")).toBe("/");
+    expect(toSafeRedirectPath(null, "/dashboard")).toBe("/dashboard");
+  });
+
+  it("allows valid relative paths", () => {
+    expect(toSafeRedirectPath("/")).toBe("/");
+    expect(toSafeRedirectPath("/onboarding")).toBe("/onboarding");
+    expect(toSafeRedirectPath("/device?user_code=abc")).toBe(
+      "/device?user_code=abc"
+    );
+    expect(toSafeRedirectPath("/invitations/test#section")).toBe(
+      "/invitations/test#section"
+    );
+    expect(toSafeRedirectPath("/org/settings?tab=billing")).toBe(
+      "/org/settings?tab=billing"
+    );
+  });
+
+  it("rejects absolute URLs", () => {
+    expect(toSafeRedirectPath("https://evil.example/phish")).toBe("/");
+    expect(toSafeRedirectPath("http://evil.example")).toBe("/");
+    expect(toSafeRedirectPath("ftp://files.example")).toBe("/");
+  });
+
+  it("rejects protocol-relative URLs", () => {
+    expect(toSafeRedirectPath("//evil.example/path")).toBe("/");
+    expect(toSafeRedirectPath("//evil.example")).toBe("/");
+  });
+
+  it("rejects javascript: scheme", () => {
+    expect(toSafeRedirectPath("javascript:alert(1)")).toBe("/");
+  });
+
+  it("rejects scheme-like paths starting with /", () => {
+    expect(toSafeRedirectPath("/javascript:alert(1)")).toBe("/");
+    expect(toSafeRedirectPath("/vbscript:msgbox")).toBe("/");
+    expect(toSafeRedirectPath("/data:text/html,<h1>hi</h1>")).toBe("/");
+  });
+
+  it("rejects percent-encoded scheme bypasses", () => {
+    expect(toSafeRedirectPath("/javascript%3aalert(1)")).toBe("/");
+    expect(toSafeRedirectPath("/javascript%3Aalert(1)")).toBe("/");
+  });
+
+  it("trims whitespace before checking", () => {
+    expect(toSafeRedirectPath("  /onboarding  ")).toBe("/onboarding");
+    expect(toSafeRedirectPath("  https://evil.example  ")).toBe("/");
+  });
+
+  it("uses custom fallback", () => {
+    expect(toSafeRedirectPath("https://evil.example", "/custom")).toBe(
+      "/custom"
+    );
+    expect(toSafeRedirectPath(null, "")).toBe("");
+  });
+});

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -6,6 +6,36 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 /**
+ * Sanitize a redirect path from query params to prevent open-redirect and XSS.
+ * Only allows relative paths starting with "/" (not protocol-relative "//").
+ * Rejects scheme-like paths (e.g. "/javascript:...") including percent-encoded variants.
+ */
+const SCHEME_PATTERN = /^\/[a-zA-Z][a-zA-Z\d+\-.]*:/;
+
+export function toSafeRedirectPath(
+  value: string | null | undefined,
+  fallback = "/"
+): string {
+  const candidate = value?.trim() ?? "";
+  if (!candidate) return fallback;
+
+  // Must start with "/" but not "//" (protocol-relative)
+  if (!candidate.startsWith("/") || candidate.startsWith("//")) return fallback;
+
+  // Reject scheme-like paths: /javascript:, /vbscript:, etc.
+  if (SCHEME_PATTERN.test(candidate)) return fallback;
+
+  // Also check decoded form to catch percent-encoded colons (%3a)
+  try {
+    if (SCHEME_PATTERN.test(decodeURIComponent(candidate))) return fallback;
+  } catch {
+    return fallback;
+  }
+
+  return candidate;
+}
+
+/**
  * Format a date as relative time (e.g., "2 hours ago", "3 days ago")
  */
 export function formatRelativeTime(date: Date): string {


### PR DESCRIPTION
## Summary
- Add `toSafeRedirectPath()` to sanitize the `?redirect=` query parameter before passing to `router.push()` and OAuth `callbackURL`
- Rejects absolute URLs, protocol-relative `//`, scheme-like paths (`/javascript:`), and percent-encoded bypasses (`/javascript%3a`)
- Applied to both sign-in and sign-up forms

Supersedes #74 (Cursor-generated) — this version removes dead code, drops unrelated activation-tracking changes, and adds proper test coverage.

## What changed
| File | Change |
|---|---|
| `apps/web/src/lib/utils.ts` | New `toSafeRedirectPath()` function |
| `apps/web/src/components/sign-in-form.tsx` | Use sanitized redirect |
| `apps/web/src/components/sign-up-form.tsx` | Use sanitized redirect |
| `apps/web/src/lib/__tests__/utils-redirect.test.ts` | 9 test cases covering happy path + attack vectors |

## Note on OAuth callbackURL
Client-side sanitization protects `router.push()` paths. For OAuth flows, better-auth's `trustedOrigins` config + Google/GitHub's registered redirect URI enforcement provide the server-side protection. An attacker bypassing the browser to call the auth API directly is still blocked by those server-side checks.

## Test plan
- [x] `toSafeRedirectPath` unit tests pass (9/9)
- [x] Existing `utils-duration` tests still pass (33/33)
- [x] TypeScript typecheck clean
- [ ] Manual: sign in with email, verify redirect works
- [ ] Manual: sign in with `?redirect=https://evil.example`, verify redirect to `/`
- [ ] Manual: sign up with `?redirect=/invitations/test`, verify special redirect preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)