### PR TITLE
feat(email): DMARCbis-aware checks + DMARC record generation

### DIFF
--- a/apps/api/src/routes/tools.ts
+++ b/apps/api/src/routes/tools.ts
@@ -62,6 +62,8 @@ const emailCheckResponseSchema = t.Object({
       record: t.Union([t.String(), t.Null()]),
       policy: t.Union([t.String(), t.Null()]),
       subdomainPolicy: t.Union([t.String(), t.Null()]),
+      nonExistentSubdomainPolicy: t.Union([t.String(), t.Null()]),
+      testing: t.Boolean(),
       reportingEnabled: t.Boolean(),
       pct: t.Union([t.Number(), t.Null()]),
       alignmentSpf: t.Union([t.String(), t.Null()]),
@@ -198,6 +200,9 @@ function formatEmailCheckResult(result: EmailCheckResult) {
       record: result.dmarc.record,
       policy: result.dmarc.policy,
       subdomainPolicy: result.dmarc.subdomainPolicy,
+      nonExistentSubdomainPolicy:
+        result.dmarc.nonExistentSubdomainPolicy ?? null,
+      testing: result.dmarc.testing ?? false,
       reportingEnabled: result.dmarc.reportingEnabled,
       pct: result.dmarc.percentage,
       alignmentSpf: result.dmarc.alignmentSpf,

--- a/apps/website/src/app/blog/your-dmarc-policy-is-useless/page.tsx
+++ b/apps/website/src/app/blog/your-dmarc-policy-is-useless/page.tsx
@@ -140,14 +140,14 @@ const THE_FIX_STEPS = [
   {
     num: 3,
     title: "Move to quarantine",
-    code: "v=DMARC1; p=quarantine; pct=25; rua=mailto:dmarc@yourcompany.com",
-    desc: "Start quarantining failures at 25%, then 50%, then 100%. Monitor for legitimate mail going to spam.",
+    code: "v=DMARC1; p=quarantine; rua=mailto:dmarc@yourcompany.com",
+    desc: "Quarantine failures and keep watching your reports. (Skip pct — DMARCbis retires it; receivers now enforce all-or-nothing. Use t=y if you need a testing window.)",
   },
   {
     num: 4,
     title: "Enforce with reject",
-    code: "v=DMARC1; p=reject; rua=mailto:dmarc@yourcompany.com; fo=1",
-    desc: "Full protection. Spoofed emails are rejected before reaching any inbox. You're now in the 5.2%.",
+    code: "v=DMARC1; p=reject; sp=reject; np=reject; rua=mailto:dmarc@yourcompany.com; fo=1",
+    desc: "Full protection. Spoofed emails are rejected before reaching any inbox. np=reject also blocks spoofing from subdomains that don't exist. You're now in the 5.2%.",
   },
 ];
 

--- a/apps/website/src/app/docs/guides/domain-verification/page-content.tsx
+++ b/apps/website/src/app/docs/guides/domain-verification/page-content.tsx
@@ -46,7 +46,7 @@ ghi789._domainkey.yourdomain.com → ghi789.dkim.amazonses.com`;
 const dmarcRecordExample = `# Add this TXT record to your DNS:
 Name:  _dmarc.yourdomain.com
 Type:  TXT
-Value: v=DMARC1; p=quarantine; rua=mailto:dmarc@yourdomain.com`;
+Value: v=DMARC1; p=quarantine; sp=quarantine; np=reject; rua=mailto:dmarc@yourdomain.com`;
 
 export default function DomainVerificationPageContent() {
   return (

--- a/apps/website/src/app/docs/guides/vercel-setup/page-content.tsx
+++ b/apps/website/src/app/docs/guides/vercel-setup/page-content.tsx
@@ -47,7 +47,7 @@ Value: v=spf1 include:amazonses.com ~all`;
 const dmarcRecordExample = `# Add this TXT record:
 Name:  _dmarc.yourdomain.com
 Type:  TXT
-Value: v=DMARC1; p=quarantine; rua=mailto:dmarc@yourdomain.com`;
+Value: v=DMARC1; p=quarantine; sp=quarantine; np=reject; rua=mailto:dmarc@yourdomain.com`;
 
 export default function VercelSetupPageContent() {
   return (

--- a/apps/website/src/app/tools/page-content.tsx
+++ b/apps/website/src/app/tools/page-content.tsx
@@ -106,6 +106,8 @@ type EmailCheckResult = {
     record: string | null;
     policy: string | null;
     subdomainPolicy: string | null;
+    nonExistentSubdomainPolicy: string | null;
+    testing: boolean;
     reportingEnabled: boolean;
     pct: number | null;
     alignmentSpf: string;
@@ -1213,10 +1215,10 @@ export default function ToolsPageContent() {
                   </div>
                   <div>
                     <div className="mb-1 text-muted-foreground text-sm">
-                      Percentage
+                      Non-Existent Subdomains
                     </div>
                     <div className="font-mono text-lg">
-                      pct={result.dmarc.pct ?? 100}
+                      np={result.dmarc.nonExistentSubdomainPolicy || "inherit"}
                     </div>
                   </div>
                   <div>

--- a/packages/cdk/src/email.ts
+++ b/packages/cdk/src/email.ts
@@ -262,7 +262,7 @@ export class WrapsEmail extends Construct {
           zone: hostedZone,
           recordName: `_dmarc.${config.domain}`,
           values: [
-            `v=DMARC1; p=quarantine; rua=mailto:postmaster@${this.mailFromDomain || config.domain}`,
+            `v=DMARC1; p=quarantine; sp=quarantine; np=reject; rua=mailto:postmaster@${this.mailFromDomain || config.domain}`,
           ],
           ttl: cdk.Duration.minutes(30),
           comment: "DMARC policy for email authentication",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -502,7 +502,7 @@ DMARC (TXT)
 Policy for how receivers handle emails failing DKIM/SPF checks
 
   TXT    _dmarc.example.com
-  →      v=DMARC1; p=quarantine; rua=mailto:postmaster@example.com
+  →      v=DMARC1; p=quarantine; sp=quarantine; np=reject; rua=mailto:postmaster@example.com
 ```
 
 ## Hosting Provider Integration

--- a/packages/cli/src/utils/dns/__tests__/create-records.test.ts
+++ b/packages/cli/src/utils/dns/__tests__/create-records.test.ts
@@ -92,7 +92,8 @@ describe("buildEmailDNSRecords", () => {
     expect(dmarcRecord).toEqual({
       name: "_dmarc.example.com",
       type: "TXT",
-      value: "v=DMARC1; p=quarantine; rua=mailto:postmaster@example.com",
+      value:
+        "v=DMARC1; p=quarantine; sp=quarantine; np=reject; rua=mailto:postmaster@example.com",
       category: "dmarc",
     });
   });
@@ -109,7 +110,7 @@ describe("buildEmailDNSRecords", () => {
     const dmarcRecord = records.find((r) => r.category === "dmarc");
 
     expect(dmarcRecord?.value).toBe(
-      "v=DMARC1; p=quarantine; rua=mailto:postmaster@mail.example.com"
+      "v=DMARC1; p=quarantine; sp=quarantine; np=reject; rua=mailto:postmaster@mail.example.com"
     );
   });
 

--- a/packages/cli/src/utils/dns/cloudflare.ts
+++ b/packages/cli/src/utils/dns/cloudflare.ts
@@ -184,7 +184,7 @@ export class CloudflareDNSClient implements DNSProviderClient {
       const dmarcSuccess = await this.createRecord(
         `_dmarc.${domain}`,
         "TXT",
-        `v=DMARC1; p=quarantine; rua=mailto:postmaster@${mailFromDomain || domain}`
+        `v=DMARC1; p=quarantine; sp=quarantine; np=reject; rua=mailto:postmaster@${mailFromDomain || domain}`
       );
       if (dmarcSuccess) {
         recordsCreated++;

--- a/packages/cli/src/utils/dns/create-records.ts
+++ b/packages/cli/src/utils/dns/create-records.ts
@@ -122,7 +122,7 @@ export function buildEmailDNSRecords(
   records.push({
     name: `_dmarc.${domain}`,
     type: "TXT",
-    value: `v=DMARC1; p=quarantine; rua=mailto:postmaster@${dmarcRuaDomain}`,
+    value: `v=DMARC1; p=quarantine; sp=quarantine; np=reject; rua=mailto:postmaster@${dmarcRuaDomain}`,
     category: "dmarc",
   });
 

--- a/packages/cli/src/utils/dns/vercel.ts
+++ b/packages/cli/src/utils/dns/vercel.ts
@@ -207,7 +207,7 @@ export class VercelDNSClient implements DNSProviderClient {
       const dmarcSuccess = await this.createRecord(
         `_dmarc.${domain}`,
         "TXT",
-        `v=DMARC1; p=quarantine; rua=mailto:postmaster@${mailFromDomain || domain}`
+        `v=DMARC1; p=quarantine; sp=quarantine; np=reject; rua=mailto:postmaster@${mailFromDomain || domain}`
       );
       if (dmarcSuccess) {
         recordsCreated++;

--- a/packages/cli/src/utils/route53.ts
+++ b/packages/cli/src/utils/route53.ts
@@ -240,7 +240,7 @@ export async function previewDNSChanges(
   // DMARC record - check for existing DMARC
   const dmarcName = `_dmarc.${domain}`;
   const dmarcRuaDomain = mailFromDomain || domain;
-  const proposedDMARC = `"v=DMARC1; p=quarantine; rua=mailto:postmaster@${dmarcRuaDomain}"`;
+  const proposedDMARC = `"v=DMARC1; p=quarantine; sp=quarantine; np=reject; rua=mailto:postmaster@${dmarcRuaDomain}"`;
   const existingDMARC = findExistingRecord(existingRecords, dmarcName, "TXT");
   const existingDMARCValue = getRecordValue(existingDMARC);
 
@@ -447,7 +447,7 @@ export async function createSelectedDNSRecords(
         TTL: 1800,
         ResourceRecords: [
           {
-            Value: `"v=DMARC1; p=quarantine; rua=mailto:postmaster@${dmarcRuaDomain}"`,
+            Value: `"v=DMARC1; p=quarantine; sp=quarantine; np=reject; rua=mailto:postmaster@${dmarcRuaDomain}"`,
           },
         ],
       },
@@ -616,7 +616,7 @@ export async function createDNSRecords(
       TTL: 1800,
       ResourceRecords: [
         {
-          Value: `"v=DMARC1; p=quarantine; rua=mailto:postmaster@${dmarcRuaDomain}"`,
+          Value: `"v=DMARC1; p=quarantine; sp=quarantine; np=reject; rua=mailto:postmaster@${dmarcRuaDomain}"`,
         },
       ],
     },

--- a/packages/cli/src/utils/shared/output.ts
+++ b/packages/cli/src/utils/shared/output.ts
@@ -233,7 +233,7 @@ export function displaySuccess(outputs: SuccessOutputs) {
         ),
         "",
         pc.bold("DMARC Record (TXT):"),
-        `  ${pc.cyan(`_dmarc.${domain}`)} ${pc.dim("TXT")} "v=DMARC1; p=quarantine; rua=mailto:postmaster@${dmarcRuaDomain}"`
+        `  ${pc.cyan(`_dmarc.${domain}`)} ${pc.dim("TXT")} "v=DMARC1; p=quarantine; sp=quarantine; np=reject; rua=mailto:postmaster@${dmarcRuaDomain}"`
       );
 
       // Add MAIL FROM domain DNS records if configured
@@ -588,7 +588,7 @@ export function displayStatus(status: StatusOutputs) {
           ),
           "",
           pc.bold("DMARC Record (TXT):"),
-          `  ${pc.cyan(`_dmarc.${domain.domain}`)} ${pc.dim("TXT")} "v=DMARC1; p=quarantine; rua=mailto:postmaster@${dmarcRuaDomain}"`
+          `  ${pc.cyan(`_dmarc.${domain.domain}`)} ${pc.dim("TXT")} "v=DMARC1; p=quarantine; sp=quarantine; np=reject; rua=mailto:postmaster@${dmarcRuaDomain}"`
         );
       }
 

--- a/packages/console/src/components/EmailSettings.tsx
+++ b/packages/console/src/components/EmailSettings.tsx
@@ -454,11 +454,12 @@ function DmarcSection({ identity }: { identity?: EmailIdentityDetails }) {
             </div>
             <div className="flex items-start justify-between gap-2">
               <p className="font-mono text-muted-foreground text-xs">
-                v=DMARC1; p=quarantine; rua=mailto:dmarc@
+                v=DMARC1; p=quarantine; sp=quarantine; np=reject;
+                rua=mailto:dmarc@
                 {identity?.identityName || "yourdomain.com"}
               </p>
               <CopyButton
-                text={`v=DMARC1; p=quarantine; rua=mailto:dmarc@${identity?.identityName || "yourdomain.com"}`}
+                text={`v=DMARC1; p=quarantine; sp=quarantine; np=reject; rua=mailto:dmarc@${identity?.identityName || "yourdomain.com"}`}
               />
             </div>
           </div>

--- a/packages/email-check/src/__tests__/dmarc.test.ts
+++ b/packages/email-check/src/__tests__/dmarc.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { checkDmarc } from "../checks/dmarc.js";
+import { nodeDns, setDnsProvider } from "../dns/index.js";
+import type { DnsProvider } from "../types.js";
+
+/** Inject a DNS provider that serves the given TXT records by name. */
+function mockDns(records: Record<string, string[]>): void {
+  const provider: DnsProvider = {
+    resolveTxt: (domain: string) =>
+      Promise.resolve((records[domain] ?? []).map((r) => [r])),
+    resolveMx: () => Promise.resolve([]),
+    resolveA: () => Promise.resolve([]),
+    resolveAaaa: () => Promise.resolve([]),
+    resolvePtr: () => Promise.resolve([]),
+    resolveCaa: () => Promise.resolve([]),
+    resolveCname: () => Promise.resolve([]),
+  };
+  setDnsProvider(provider);
+}
+
+afterEach(() => {
+  setDnsProvider(nodeDns);
+});
+
+describe("DMARCbis parsing", () => {
+  it("parses np, t, and psd tags", async () => {
+    mockDns({
+      "_dmarc.example.com": [
+        "v=DMARC1; p=reject; sp=reject; np=reject; t=n; psd=n; rua=mailto:dmarc@example.com",
+      ],
+    });
+
+    const result = await checkDmarc("example.com");
+
+    expect(result.valid).toBe(true);
+    expect(result.policy).toBe("reject");
+    expect(result.nonExistentSubdomainPolicy).toBe("reject");
+    expect(result.testing).toBe(false);
+    expect(result.psd).toBe("n");
+  });
+
+  it("flags t=y as testing (policy not enforced)", async () => {
+    mockDns({
+      "_dmarc.example.com": [
+        "v=DMARC1; p=reject; t=y; rua=mailto:dmarc@example.com",
+      ],
+    });
+
+    const result = await checkDmarc("example.com");
+
+    expect(result.testing).toBe(true);
+    expect(result.warnings.some((w) => w.includes("t=y"))).toBe(true);
+  });
+
+  it("recommends np= when enforcing but np is absent", async () => {
+    mockDns({
+      "_dmarc.example.com": [
+        "v=DMARC1; p=quarantine; rua=mailto:d@example.com",
+      ],
+    });
+
+    const result = await checkDmarc("example.com");
+
+    expect(result.nonExistentSubdomainPolicy).toBeNull();
+    expect(result.warnings.some((w) => w.includes("np="))).toBe(true);
+  });
+
+  it("marks pct as deprecated instead of a sampling knob", async () => {
+    mockDns({
+      "_dmarc.example.com": [
+        "v=DMARC1; p=quarantine; pct=25; rua=mailto:d@example.com",
+      ],
+    });
+
+    const result = await checkDmarc("example.com");
+
+    expect(result.percentage).toBe(25);
+    expect(
+      result.warnings.some((w) => w.toLowerCase().includes("deprecated"))
+    ).toBe(true);
+  });
+
+  it("rejects an invalid np value with a warning", async () => {
+    mockDns({
+      "_dmarc.example.com": [
+        "v=DMARC1; p=reject; np=bogus; rua=mailto:d@example.com",
+      ],
+    });
+
+    const result = await checkDmarc("example.com");
+
+    expect(result.nonExistentSubdomainPolicy).toBeNull();
+    expect(result.warnings.some((w) => w.includes("np"))).toBe(true);
+  });
+});

--- a/packages/email-check/src/__tests__/scoring.test.ts
+++ b/packages/email-check/src/__tests__/scoring.test.ts
@@ -451,6 +451,49 @@ describe("calculateScore", () => {
   });
 });
 
+describe("DMARCbis scoring", () => {
+  it("rewards np=reject with a bonus when enforcing", () => {
+    const checks = createBaseChecks();
+    checks.dmarc.nonExistentSubdomainPolicy = "reject";
+
+    const result = calculateScore(checks);
+
+    expect(
+      result.bonuses.some(
+        (bonus) => bonus.check === "dmarc" && bonus.reason.includes("np=reject")
+      )
+    ).toBe(true);
+  });
+
+  it("penalizes DMARC testing mode (t=y) while a policy is set", () => {
+    const checks = createBaseChecks();
+    checks.dmarc.testing = true;
+
+    const result = calculateScore(checks);
+
+    expect(
+      result.deductions.some(
+        (deduction) =>
+          deduction.check === "dmarc" && deduction.reason.includes("testing")
+      )
+    ).toBe(true);
+  });
+
+  it("treats pct<100 as a deprecation nudge, not a hard penalty", () => {
+    const checks = createBaseChecks();
+    checks.dmarc.percentage = 25;
+
+    const result = calculateScore(checks);
+
+    const pctDeduction = result.deductions.find(
+      (deduction) =>
+        deduction.check === "dmarc" && deduction.reason.includes("pct")
+    );
+    expect(pctDeduction?.points).toBe(1);
+    expect(pctDeduction?.reason).toContain("deprecated");
+  });
+});
+
 describe("grade helpers", () => {
   it("maps grades to terminal colors", () => {
     expect(getGradeColor("A")).toBe("green");

--- a/packages/email-check/src/checks/dmarc.ts
+++ b/packages/email-check/src/checks/dmarc.ts
@@ -16,6 +16,9 @@ export async function checkDmarc(domain: string): Promise<DmarcResult> {
     valid: false,
     policy: null,
     subdomainPolicy: null,
+    nonExistentSubdomainPolicy: null,
+    testing: false,
+    psd: null,
     percentage: 100,
     reportingEnabled: false,
     ruaAddresses: [],
@@ -90,7 +93,31 @@ function parseDmarcRecord(record: string, result: DmarcResult): void {
     result.subdomainPolicy = result.policy;
   }
 
-  // Get percentage
+  // Get non-existent subdomain policy (np) — DMARCbis / RFC 9989.
+  // Closes the phantom-subdomain spoofing gap that p= and sp= don't cover.
+  const np = tags.get("np");
+  if (np) {
+    if (["none", "quarantine", "reject"].includes(np)) {
+      result.nonExistentSubdomainPolicy =
+        np as DmarcResult["nonExistentSubdomainPolicy"];
+    } else {
+      result.warnings.push(`Invalid non-existent subdomain policy (np): ${np}`);
+    }
+  }
+
+  // Testing flag (t=y) — DMARCbis's replacement for pct-based ramping.
+  // When set, receivers apply the policy for reporting but not disposition.
+  if (tags.get("t") === "y") {
+    result.testing = true;
+  }
+
+  // Public suffix domain declaration (psd) — DMARCbis / RFC 9989
+  const psd = tags.get("psd");
+  if (psd && ["y", "n", "u"].includes(psd)) {
+    result.psd = psd as DmarcResult["psd"];
+  }
+
+  // Get percentage (pct) — retired in DMARCbis; receivers ignore it
   const pct = tags.get("pct");
   if (pct) {
     const pctNum = Number.parseInt(pct, 10);
@@ -99,7 +126,9 @@ function parseDmarcRecord(record: string, result: DmarcResult): void {
     } else {
       result.percentage = pctNum;
       if (pctNum < 100) {
-        result.warnings.push(`Only ${pctNum}% of messages subject to policy`);
+        result.warnings.push(
+          `pct=${pctNum} is deprecated (DMARCbis receivers ignore it; enforcement is all-or-nothing). Use t=y while testing instead.`
+        );
       }
     }
   }
@@ -180,6 +209,21 @@ function parseDmarcRecord(record: string, result: DmarcResult): void {
 
   if (result.subdomainPolicy === "none" && result.policy !== "none") {
     result.warnings.push("Subdomain policy is less strict than domain policy");
+  }
+
+  const enforcing =
+    result.policy === "quarantine" || result.policy === "reject";
+
+  if (result.testing && result.policy !== "none") {
+    result.warnings.push(
+      "t=y (testing) is set — receivers will not enforce the policy"
+    );
+  }
+
+  if (enforcing && !result.nonExistentSubdomainPolicy) {
+    result.warnings.push(
+      "No np= set — add np=reject to block spoofing from non-existent subdomains (DMARCbis)"
+    );
   }
 
   if (!result.reportingEnabled) {

--- a/packages/email-check/src/scoring.ts
+++ b/packages/email-check/src/scoring.ts
@@ -385,11 +385,18 @@ function collectDmarcIssues(
       reason: "DMARC policy is none (not enforcing)",
     });
   }
-  if (dmarc.percentage < 100) {
+  if (dmarc.testing && dmarc.policy !== "none") {
     deductions.push({
       check: "dmarc",
       points: 2,
-      reason: `DMARC pct=${dmarc.percentage} (not 100%)`,
+      reason: "DMARC testing mode (t=y) — receivers won't enforce the policy",
+    });
+  }
+  if (dmarc.percentage < 100) {
+    deductions.push({
+      check: "dmarc",
+      points: 1,
+      reason: `DMARC pct=${dmarc.percentage} is deprecated (DMARCbis receivers ignore it; enforcement is inconsistent)`,
     });
   }
   if (!dmarc.reportingEnabled) {
@@ -404,6 +411,16 @@ function collectDmarcIssues(
       check: "dmarc",
       points: 1,
       reason: "DMARC strict alignment configured",
+    });
+  }
+  if (
+    (dmarc.policy === "quarantine" || dmarc.policy === "reject") &&
+    dmarc.nonExistentSubdomainPolicy === "reject"
+  ) {
+    bonuses.push({
+      check: "dmarc",
+      points: 1,
+      reason: "np=reject blocks non-existent subdomain spoofing (DMARCbis)",
     });
   }
 }

--- a/packages/email-check/src/types.ts
+++ b/packages/email-check/src/types.ts
@@ -109,6 +109,13 @@ export type DmarcResult = {
   valid: boolean;
   policy: "none" | "quarantine" | "reject" | null;
   subdomainPolicy: "none" | "quarantine" | "reject" | null;
+  /** np= tag — policy for non-existent subdomains (DMARCbis / RFC 9989) */
+  nonExistentSubdomainPolicy?: "none" | "quarantine" | "reject" | null;
+  /** t=y tag — testing mode; DMARCbis receivers won't enforce the policy */
+  testing?: boolean;
+  /** psd= tag — public suffix domain declaration (DMARCbis / RFC 9989) */
+  psd?: "y" | "n" | "u" | null;
+  /** @deprecated pct= is retired in DMARCbis; receivers ignore it */
   percentage: number;
   reportingEnabled: boolean;
   ruaAddresses: string[];

--- a/packages/pulumi/src/resources/dns.ts
+++ b/packages/pulumi/src/resources/dns.ts
@@ -93,7 +93,7 @@ function createRoute53Records(
       type: "TXT",
       ttl: 1800,
       records: [
-        `v=DMARC1; p=quarantine; rua=mailto:postmaster@${mailFromDomain || domain}`,
+        `v=DMARC1; p=quarantine; sp=quarantine; np=reject; rua=mailto:postmaster@${mailFromDomain || domain}`,
       ],
     },
     opts
@@ -185,7 +185,7 @@ function createCloudflareRecords(
       zoneId: config.zoneId,
       name: `_dmarc.${domain}`,
       type: "TXT",
-      content: `v=DMARC1; p=quarantine; rua=mailto:postmaster@${mailFromDomain || domain}`,
+      content: `v=DMARC1; p=quarantine; sp=quarantine; np=reject; rua=mailto:postmaster@${mailFromDomain || domain}`,
       ttl: 1800,
     },
     cfOpts
@@ -294,7 +294,7 @@ function createVercelRecords(
   createVercelRecord(
     `${name}-dmarc`,
     "TXT",
-    `v=DMARC1; p=quarantine; rua=mailto:postmaster@${mailFromDomain || domain}`,
+    `v=DMARC1; p=quarantine; sp=quarantine; np=reject; rua=mailto:postmaster@${mailFromDomain || domain}`,
     `_dmarc.${domain}`
   );
 


### PR DESCRIPTION
## Why

[DMARCbis shipped as RFC 9989/9990/9991 (May 2026)](https://www.rfc-editor.org/info/rfc9989) — it retires `pct`, adds the `np` tag (non-existent subdomain policy) and `t=y` testing flag, and replaces the Public Suffix List with a DNS tree walk. Our `email-check` scoring still penalized `pct`, our tools/blog still taught `pct=` ramping, and every DMARC record we generate omitted `sp`/`np`. SES ships **neither** DKIM2 (still an IETF draft) nor DMARCbis report emission yet, so this keeps our tooling ahead of the SES console.

## What

### Bug / tech-debt — `email-check` DMARCbis awareness
- **Parser** (`checks/dmarc.ts`): recognize `np`, `t=y`, `psd`; reframe `pct<100` as *deprecated* (DMARCbis receivers ignore it) and point users to `t=y` for testing windows; warn when an enforcing policy has no `np`.
- **Scoring** (`scoring.ts`): deduct for `t=y` testing mode (policy not enforced), award a bonus for `np=reject`, and drop the `pct` deduction from a 2pt penalty to a 1pt deprecation nudge.
- **Types / API / UI**: expose `nonExistentSubdomainPolicy` + `testing` through the tools API; the website checker now shows an **np** tile instead of the retired **pct** tile.
- **Blog** (`your-dmarc-policy-is-useless`): stop teaching the `pct=25` ramp; teach `sp=reject; np=reject` enforcement instead.

### Feature + safety — DMARCbis-complete generated records
Every record Wraps **generates or documents** now emits `sp=quarantine; np=reject`:
Pulumi, CDK, CLI (route53 / vercel / cloudflare / create-records / output), the **console dashboard** copy-paste record, both docs guides, and the CLI README.

**Safety audit (why this can't block Wraps' own sending):**
- `np` only applies to **non-existent** subdomains (NXDOMAIN). Wraps always creates DNS records (MX + SPF) for its MAIL FROM subdomain, so it *exists* → `np=reject` never touches it.
- `sp=quarantine` merely makes the already-inherited default explicit (absent `sp` inherits `p`), so it changes no disposition.
- Header-`From` alignment is unchanged; Wraps mail stays DKIM+SPF aligned and passes.

## Tests
- New `email-check/__tests__/dmarc.test.ts` (np/t/psd parsing, pct deprecation, np recommendation, invalid-np handling) via injected DNS provider.
- New DMARCbis scoring cases (np bonus, t=y penalty, pct nudge).
- Updated CLI `create-records` string assertions.
- Green: `email-check` (60), CLI dns, API tools-routes, root architecture (27), all touched-package typechecks, `pnpm baseline` ratchets.

## Follow-ups (not in this PR)
- **DKIM2**: watch-only until SES adds signing — no crypto to implement, only a future verification surface.
- **DMARC report ingestion**: when the ops console parses RUA reports, handle the `urn:ietf:params:xml:ns:dmarc-2.0` namespace, `discovery_method`, and the now-required DKIM selector.
- The generated DMARC string is duplicated across ~13 sites; a shared helper would be a sensible future consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)