### PR TITLE
Fix docs search: enable Cmd-K on docs pages + match content + auto-sync with nav

### DIFF
--- a/apps/website/src/components/command-search.tsx
+++ b/apps/website/src/components/command-search.tsx
@@ -19,7 +19,6 @@ import {
   Globe,
   KeyRound,
   Layers,
-  type LucideIcon,
   Mail,
   MessageSquare,
   Radio,
@@ -37,6 +36,7 @@ import {
 import { useRouter } from "next/navigation";
 import * as React from "react";
 import { cn } from "@/lib/utils";
+import { type NavItem, navItems } from "./docs-nav";
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -130,7 +130,7 @@ type SearchItem = {
   description: string;
   url: string;
   group: string;
-  icon?: LucideIcon;
+  icon?: React.ComponentType<{ className?: string }>;
 };
 
 type CommandSearchProps = {
@@ -552,7 +552,40 @@ export function CommandSearch({ open, onOpenChange }: CommandSearchProps) {
     },
   ];
 
-  const groupedItems = searchItems.reduce(
+  // Auto-append any docs-nav route not already curated above, so the palette
+  // can never drift out of sync with the sidebar. Curated entries keep their
+  // rich descriptions; derived entries are still matchable by title and section.
+  const curatedUrls = new Set(searchItems.map((item) => item.url));
+  const flattenNav = (
+    items: NavItem[],
+    group: string,
+    fallbackIcon: React.ComponentType<{ className?: string }>
+  ): SearchItem[] =>
+    items.flatMap((item) => {
+      const icon = item.icon ?? fallbackIcon;
+      const self: SearchItem[] =
+        curatedUrls.has(item.href) || item.disabled
+          ? []
+          : [
+              {
+                title: item.title,
+                description: "",
+                url: item.href,
+                group,
+                icon,
+              },
+            ];
+      const children = item.children
+        ? flattenNav(item.children, group, icon)
+        : [];
+      return [...self, ...children];
+    });
+  const derivedItems = navItems.flatMap((section) =>
+    flattenNav(section.items, section.title, FileCode2)
+  );
+  const allItems = [...searchItems, ...derivedItems];
+
+  const groupedItems = allItems.reduce(
     (acc, item) => {
       if (!acc[item.group]) {
         acc[item.group] = [];
@@ -595,8 +628,13 @@ export function CommandSearch({ open, onOpenChange }: CommandSearchProps) {
                   return (
                     <CommandItem
                       key={item.url}
+                      keywords={[
+                        item.title,
+                        item.description,
+                        item.group,
+                      ].filter(Boolean)}
                       onSelect={() => handleSelect(item.url)}
-                      value={item.title}
+                      value={item.url}
                     >
                       {Icon && (
                         <Icon className="mr-2 h-4 w-4 shrink-0 self-start mt-0.5" />

--- a/apps/website/src/components/docs-layout.tsx
+++ b/apps/website/src/components/docs-layout.tsx
@@ -3,7 +3,8 @@
 import { Button } from "@wraps/ui/components/ui/button";
 import { Menu, X } from "lucide-react";
 import Link from "next/link";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { CommandSearch, SearchTrigger } from "@/components/command-search";
 import { Logo } from "@/components/logo";
 import { DocsNav } from "./docs-nav";
 import { DocsToc } from "./docs-toc";
@@ -15,7 +16,21 @@ type DocsLayoutProps = {
 
 export function DocsLayout({ children, headerActions }: DocsLayoutProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
+
+  // Cmd/Ctrl+K opens the command palette on docs pages (which don't render the
+  // marketing SiteHeader that hosts it elsewhere).
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setSearchOpen((open) => !open);
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, []);
 
   return (
     <div className="min-h-screen bg-background">
@@ -44,6 +59,9 @@ export function DocsLayout({ children, headerActions }: DocsLayoutProps) {
 
           {/* Navigation */}
           <div className="ml-auto flex items-center gap-2">
+            <div className="hidden w-40 sm:block lg:w-56">
+              <SearchTrigger onClick={() => setSearchOpen(true)} />
+            </div>
             {headerActions}
             <Button asChild variant="ghost">
               <Link href="/docs">Docs</Link>
@@ -54,6 +72,8 @@ export function DocsLayout({ children, headerActions }: DocsLayoutProps) {
           </div>
         </div>
       </header>
+
+      <CommandSearch onOpenChange={setSearchOpen} open={searchOpen} />
 
       <div className="container mx-auto flex px-4 sm:px-6 lg:px-8">
         {/* Sidebar - Desktop */}

--- a/apps/website/src/components/docs-nav.tsx
+++ b/apps/website/src/components/docs-nav.tsx
@@ -33,7 +33,7 @@ import { usePathname } from "next/navigation";
 import { useState } from "react";
 import { cn } from "@/lib/utils";
 
-type NavItem = {
+export type NavItem = {
   title: string;
   href: string;
   icon?: React.ComponentType<{ className?: string }>;
@@ -42,12 +42,12 @@ type NavItem = {
   children?: NavItem[];
 };
 
-type NavSection = {
+export type NavSection = {
   title: string;
   items: NavItem[];
 };
 
-const navItems: NavSection[] = [
+export const navItems: NavSection[] = [
   {
     title: "Getting Started",
     items: [

--- a/apps/website/src/components/docs-toc.tsx
+++ b/apps/website/src/components/docs-toc.tsx
@@ -18,6 +18,19 @@ function slugify(text: string): string {
     .replace(/^-|-$/g, "");
 }
 
+// Return `base`, or `base-2`, `base-3`, … so repeated heading text (e.g. several
+// "Parameters" sections) yields unique ids. Records the result in `used`.
+function uniqueId(base: string, used: Set<string>): string {
+  let id = base;
+  let suffix = 2;
+  while (used.has(id)) {
+    id = `${base}-${suffix}`;
+    suffix += 1;
+  }
+  used.add(id);
+  return id;
+}
+
 export function DocsToc({
   contentRef,
 }: {
@@ -36,6 +49,7 @@ export function DocsToc({
 
     const headings = container.querySelectorAll("h2, h3");
     const tocItems: TocItem[] = [];
+    const usedIds = new Set<string>();
 
     for (const heading of headings) {
       const el = heading as HTMLElement;
@@ -64,16 +78,21 @@ export function DocsToc({
         continue;
       }
 
-      if (!el.id) {
-        const slug = slugify(text);
-        if (!slug) {
-          continue;
-        }
-        el.id = slug;
+      const baseId = el.id || slugify(text);
+      if (!baseId) {
+        continue;
+      }
+
+      // Guarantee a unique id even when several headings share the same text —
+      // otherwise the TOC emits duplicate React keys and the page has duplicate
+      // anchors that break scroll-to.
+      const id = uniqueId(baseId, usedIds);
+      if (el.id !== id) {
+        el.id = id;
       }
 
       tocItems.push({
-        id: el.id,
+        id,
         text,
         level: el.tagName === "H2" ? 2 : 3,
       });


### PR DESCRIPTION
## The core problem

**Docs pages had no search at all.** They use `DocsLayout`, which never rendered the `SiteHeader` that hosts the command palette everywhere else — so **Cmd-K and search were entirely unavailable on `/docs/*`**, the place they matter most. (I only found this because you asked whether Cmd-K works on docs pages — it didn't.)

## Three fixes (one cohesive change)

**1. Make search reachable on docs pages.** Mount `CommandSearch` + a Cmd/Ctrl+K listener in `DocsLayout`, and add the existing `SearchTrigger` button (with the ⌘K hint) to the docs header — a visible affordance, not just a hidden shortcut.

**2. Match content, not just titles.** Each item passes `keywords` (title + description + section) to `cmdk`, with the unique URL as `value`. Queries like `suppression`, `bounce`, `DKIM`, `assume role` now resolve instead of returning nothing.

**3. Auto-sync with the sidebar.** Export `navItems` from `docs-nav.tsx`; the palette auto-appends any docs route not already curated. Coverage can't drift — new pages are searchable the moment they're in the nav.

## Verify (Vercel preview)

On any `/docs/*` page: press **⌘K** (or click the new **Search…** button) and try `suppression`, `bounce`, `reply threading`. Previously there was no search here at all.

## Notes
- Search button shows from `sm` up; mobile still relies on nav (a compact mobile search icon is a good follow-up).
- `tsc -b` clean · `docs-nav` test passing · Biome clean on changed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfF3tkuz2tWJkT543cdYbJ