### PR TITLE
Reorganize Email docs nav: Quickstart / Features / Guides

### DIFF
--- a/apps/website/src/components/docs-nav.tsx
+++ b/apps/website/src/components/docs-nav.tsx
@@ -13,7 +13,6 @@ import {
   FileCode2,
   FileJson,
   FileText,
-  Globe,
   History,
   KeyRound,
   Layers,
@@ -24,9 +23,7 @@ import {
   Server,
   Settings,
   ShieldCheck,
-  Sliders,
   Terminal,
-  Workflow,
   Zap,
 } from "lucide-react";
 import { usePathname } from "next/navigation";
@@ -104,10 +101,41 @@ const navItems: NavSection[] = [
             title: "Cloudflare Workers",
             href: "/docs/quickstart/email/cloudflare",
           },
+        ],
+      },
+      {
+        title: "Features",
+        href: "/docs/quickstart/email/inbound",
+        icon: Blocks,
+        children: [
           { title: "Inbound", href: "/docs/quickstart/email/inbound" },
           { title: "Templates", href: "/docs/quickstart/email/templates" },
           { title: "Workflows", href: "/docs/quickstart/email/workflows" },
           { title: "Agents", href: "/docs/quickstart/email/agents" },
+          { title: "Reply Threading", href: "/docs/guides/reply-threading" },
+        ],
+      },
+      {
+        title: "Guides",
+        href: "/docs/guides/domain-verification",
+        icon: BookOpen,
+        children: [
+          {
+            title: "Domain Verification",
+            href: "/docs/guides/domain-verification",
+          },
+          {
+            title: "Production Access",
+            href: "/docs/guides/production-access",
+          },
+          { title: "SMTP Credentials", href: "/docs/guides/smtp" },
+          { title: "Webhooks", href: "/docs/guides/webhooks" },
+          { title: "Templates as Code", href: "/docs/guides/templates" },
+          { title: "Building Workflows", href: "/docs/guides/workflows" },
+          {
+            title: "Configuration Presets",
+            href: "/docs/guides/configuration-presets",
+          },
         ],
       },
       {
@@ -134,46 +162,6 @@ const navItems: NavSection[] = [
         title: "Infrastructure",
         href: "/docs/infrastructure/email",
         icon: Server,
-      },
-      {
-        title: "Domain Verification",
-        href: "/docs/guides/domain-verification",
-        icon: Globe,
-      },
-      {
-        title: "Production Access",
-        href: "/docs/guides/production-access",
-        icon: ShieldCheck,
-      },
-      {
-        title: "SMTP Credentials",
-        href: "/docs/guides/smtp",
-        icon: KeyRound,
-      },
-      {
-        title: "Webhooks",
-        href: "/docs/guides/webhooks",
-        icon: Zap,
-      },
-      {
-        title: "Reply Threading",
-        href: "/docs/guides/reply-threading",
-        icon: Radio,
-      },
-      {
-        title: "Templates Guide",
-        href: "/docs/guides/templates",
-        icon: FileCode2,
-      },
-      {
-        title: "Workflows Guide",
-        href: "/docs/guides/workflows",
-        icon: Workflow,
-      },
-      {
-        title: "Configuration Presets",
-        href: "/docs/guides/configuration-presets",
-        icon: Sliders,
       },
     ],
   },
@@ -374,7 +362,7 @@ function NavItemComponent({
       <div
         className={cn(
           "group flex items-center rounded-md text-sm transition-colors",
-          isActive
+          isActive && !isChildActive
             ? "bg-primary/10 font-medium text-primary"
             : isChildActive
               ? "font-medium text-foreground"


### PR DESCRIPTION
## Problem

The Email section's IA was muddled:
- **Quickstart** conflated framework quickstarts (Next.js, Express, Remix, Cloudflare) with *feature* pages (Inbound, Templates, Workflows, Agents).
- Guides sat **loose** at the top level in an unscannable pile.
- **Confusing "duplicates":** "Templates" (under Quickstart) vs "Templates Guide", same for Workflows — which turned out to be legit **intro vs deep-dive** pairs, just poorly presented.

## New structure

```
Quickstart ▸   Next.js · Express · Remix · Cloudflare Workers
Features ▸     Inbound · Templates · Workflows · Agents · Reply Threading   (the intros)
Guides ▸       Domain Verification · Production Access · SMTP · Webhooks ·
               Templates as Code · Building Workflows · Configuration Presets
TypeScript SDK · Python SDK · MCP Server · CLI Commands · Infrastructure
```

- Features and Guides are collapsible groups like Quickstart.
- The intro/deep-dive pairs are **differentiated, not consolidated**: intros live under Features, deep-dives under Guides renamed to their real titles (`Templates as Code`, `Building Workflows`) so they no longer read as dupes. No routes changed, no redirects.
- Renderer tweak: a group parent no longer double-highlights with its active child.
- **SMS/CDN** already follow the convention (Quickstart → SDK/CLI → Infra) — no change needed.

## Verify (Vercel preview)

Open any `/docs/email/*` page: Features and Guides are now their own dropdowns, distinct from Quickstart.

- `tsc -b` clean · `docs-nav` test passing · Biome clean (one pre-existing nested-ternary warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfF3tkuz2tWJkT543cdYbJ