### PR TITLE
fix(api): scope middleware derives so plan gates and rate limits actually run

### DIFF
--- a/apps/api/src/__tests__/middleware-scope.test.ts
+++ b/apps/api/src/__tests__/middleware-scope.test.ts
@@ -1,0 +1,131 @@
+import { Elysia } from "elysia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockDynamoSend, mockIsSelfHosted } = vi.hoisted(() => ({
+  mockDynamoSend: vi.fn(),
+  mockIsSelfHosted: vi.fn(),
+}));
+
+// The shared .env.test carries a WRAPS_LICENSE_KEY, so isSelfHosted() is true
+// by default under `pnpm test` and every plan/rate gate short-circuits. Pin it
+// so these tests exercise the gate itself rather than the ambient env.
+vi.mock("../(ee)/lib/license", () => ({ isSelfHosted: mockIsSelfHosted }));
+
+vi.mock("@aws-sdk/client-dynamodb", () => ({
+  DynamoDBClient: class {
+    send = mockDynamoSend;
+  },
+  UpdateItemCommand: class {
+    constructor(public input: unknown) {}
+  },
+}));
+
+import { planGateMiddleware } from "../middleware/plan-gate";
+import { publicRateLimitMiddleware } from "../middleware/public-rate-limit";
+import { rateLimitMiddleware } from "../middleware/rate-limit";
+
+/**
+ * Elysia scoping regression guard.
+ *
+ * A plugin's `derive` defaults to `local` scope: it applies only to routes
+ * defined on the plugin instance itself, NOT to routes on the instance that
+ * `.use()`s it. Every one of these middlewares is consumed the second way
+ * (batch.ts:133-134, tools.ts:275, workflows.ts:45), so without an explicit
+ * `{ as: "scoped" }` they are silently no-ops — the guard never runs and the
+ * request sails through. Nothing else in the suite covers this: the tools
+ * route test mocks the rate limiter out entirely.
+ */
+
+/** Mirrors how createAuthenticatedRoutes supplies `auth` to downstream plugins. */
+function withAuth(planId: string | null) {
+  return new Elysia().derive(() => ({
+    auth: {
+      organizationId: "org-1",
+      apiKeyId: "key-1",
+      userId: null,
+      planId,
+    },
+  }));
+}
+
+beforeEach(() => {
+  mockDynamoSend.mockReset();
+  mockDynamoSend.mockResolvedValue({ Attributes: { count: { N: "1" } } });
+  mockIsSelfHosted.mockReset();
+  mockIsSelfHosted.mockReturnValue(false);
+});
+
+describe("planGateMiddleware applies to the consumer's routes", () => {
+  it("blocks a free-plan org from a starter-gated feature", async () => {
+    const app = withAuth("free")
+      .use(planGateMiddleware("batch"))
+      .get("/v1/batch", () => ({ ok: true }));
+
+    const res = await app.handle(new Request("http://localhost/v1/batch"));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("skips the gate entirely for licensed self-hosted deployments", async () => {
+    mockIsSelfHosted.mockReturnValue(true);
+    const app = withAuth("free")
+      .use(planGateMiddleware("batch"))
+      .get("/v1/batch", () => ({ ok: true }));
+
+    const res = await app.handle(new Request("http://localhost/v1/batch"));
+
+    expect(res.status).toBe(200);
+  });
+
+  it("lets a paid org through", async () => {
+    const app = withAuth("scale")
+      .use(planGateMiddleware("batch"))
+      .get("/v1/batch", () => ({ ok: true }));
+
+    const res = await app.handle(new Request("http://localhost/v1/batch"));
+
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("rateLimitMiddleware applies to the consumer's routes", () => {
+  it("counts a request against the org's quota", async () => {
+    const app = withAuth("scale")
+      .use(rateLimitMiddleware)
+      .get("/v1/batch", () => ({ ok: true }));
+
+    await app.handle(new Request("http://localhost/v1/batch"));
+
+    expect(mockDynamoSend).toHaveBeenCalled();
+  });
+});
+
+describe("publicRateLimitMiddleware applies to the consumer's routes", () => {
+  it("counts an unauthenticated request against the IP quota", async () => {
+    const app = new Elysia()
+      .use(publicRateLimitMiddleware)
+      .get("/tools/email-check", () => ({ ok: true }));
+
+    await app.handle(
+      new Request("http://localhost/tools/email-check", {
+        headers: { "x-source-ip": "1.2.3.4" },
+      })
+    );
+
+    expect(mockDynamoSend).toHaveBeenCalled();
+  });
+
+  it("does not leak onto sibling route groups that never opted in", async () => {
+    const guarded = new Elysia({ prefix: "/tools" })
+      .use(publicRateLimitMiddleware)
+      .get("/email-check", () => ({ ok: true }));
+    const open = new Elysia({ prefix: "/health" }).get("/", () => ({
+      ok: true,
+    }));
+    const root = new Elysia().use(guarded).use(open);
+
+    await root.handle(new Request("http://localhost/health/"));
+
+    expect(mockDynamoSend).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/middleware/plan-gate.ts
+++ b/apps/api/src/middleware/plan-gate.ts
@@ -35,34 +35,37 @@ const PLAN_HIERARCHY = {
 type PlanId = keyof typeof PLAN_HIERARCHY;
 
 export function planGateMiddleware(feature: Feature) {
-  return new Elysia({ name: `plan-gate:${feature}` }).derive(async (ctx) => {
-    const authContext = getAuthOptional(ctx);
-    const { set } = ctx;
+  return new Elysia({ name: `plan-gate:${feature}` }).derive(
+    { as: "scoped" },
+    async (ctx) => {
+      const authContext = getAuthOptional(ctx);
+      const { set } = ctx;
 
-    if (!authContext) {
-      set.status = 401;
-      throw new Error("Not authenticated");
-    }
+      if (!authContext) {
+        set.status = 401;
+        throw new Error("Not authenticated");
+      }
 
-    // Self-hosted deployments are licensed — all features unlocked.
-    if (isSelfHosted()) {
+      // Self-hosted deployments are licensed — all features unlocked.
+      if (isSelfHosted()) {
+        return {};
+      }
+
+      const { planId } = authContext;
+      const requiredPlan = FEATURE_PLANS[feature];
+
+      const currentLevel = PLAN_HIERARCHY[planId as PlanId] ?? 0;
+      const requiredLevel = PLAN_HIERARCHY[requiredPlan as PlanId] ?? 0;
+
+      if (currentLevel < requiredLevel) {
+        set.status = 403;
+        throw new Error(
+          `Feature '${feature}' requires ${requiredPlan} plan or higher. ` +
+            `Current plan: ${planId}. Upgrade at https://wraps.dev/upgrade`
+        );
+      }
+
       return {};
     }
-
-    const { planId } = authContext;
-    const requiredPlan = FEATURE_PLANS[feature];
-
-    const currentLevel = PLAN_HIERARCHY[planId as PlanId] ?? 0;
-    const requiredLevel = PLAN_HIERARCHY[requiredPlan as PlanId] ?? 0;
-
-    if (currentLevel < requiredLevel) {
-      set.status = 403;
-      throw new Error(
-        `Feature '${feature}' requires ${requiredPlan} plan or higher. ` +
-          `Current plan: ${planId}. Upgrade at https://wraps.dev/upgrade`
-      );
-    }
-
-    return {};
-  });
+  );
 }

--- a/apps/api/src/middleware/public-rate-limit.ts
+++ b/apps/api/src/middleware/public-rate-limit.ts
@@ -115,7 +115,7 @@ function getHourKey(ip: string): string {
  */
 export const publicRateLimitMiddleware = new Elysia({
   name: "public-rate-limit",
-}).derive(async ({ request, set }) => {
+}).derive({ as: "scoped" }, async ({ request, set }) => {
   const clientIp = getClientIp(request);
 
   // Check minute limit

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -27,6 +27,7 @@ const dynamoClient = new DynamoDBClient(awsDefaults);
 const TABLE_NAME = process.env.RATE_LIMIT_TABLE_NAME ?? "RateLimitTable";
 
 export const rateLimitMiddleware = new Elysia({ name: "rate-limit" }).derive(
+  { as: "scoped" },
   async (ctx) => {
     const authContext = getAuthOptional(ctx);
 


### PR DESCRIPTION
## Summary
Three middlewares have been silent no-ops. Elysia's `derive` defaults to `local` scope — it applies only to routes defined on the plugin instance itself, **not** to routes on the instance that `.use()`s it. All three are consumed the second way.

| Middleware | Consumer | What wasn't happening |
|---|---|---|
| `planGateMiddleware("batch")` | `batch.ts:134` | Free-plan orgs were never blocked from a Starter+ feature |
| `rateLimitMiddleware` | `batch.ts:133`, `workflows.ts:45` | Per-org send rate limits were never counted |
| `publicRateLimitMiddleware` | `tools.ts:275` | The public, unauthenticated `/tools/email-check` endpoint had no IP rate limiting |

`createAuthenticatedRoutes()` is unaffected — it calls `.derive()` inline on the instance that owns the routes, which is why auth works and why this went unnoticed.

## Evidence
Against the **real** middleware, not a reconstruction: mounting `publicRateLimitMiddleware` on a consumer instance and issuing a request produced **zero** DynamoDB calls. The new `middleware-scope.test.ts` fails 3/5 without this change and passes 6/6 with it.

`{ as: "scoped" }` applies the hook to the consumer's routes and no further — a sibling route group that never opted in stays untouched, which `global` would not respect. There's a test pinning that.

## Why nothing caught it
- `tools-routes.test.ts:34` mocks `publicRateLimitMiddleware` out entirely, replacing it with a bare `new Elysia()`.
- `rate-limit-ip-spoofing.test.ts` only unit-tests `getClientIp`.
- `plan-gate.test.ts` only asserts the `FEATURE_PLANS` constant.

The new test mounts each real middleware through the same composition shape the routes use. It also pins `isSelfHosted` — the shared `apps/web/.env.test` carries a `WRAPS_LICENSE_KEY`, so **every plan and rate gate short-circuits by default under `pnpm test`**. Any future test of gated behavior needs that mock or it silently asserts nothing.

## ⚠️ Production behavior change
This turns on enforcement that has been off. Before merging, worth checking:
- **Free-plan orgs currently using batch send will start getting 403s.** If any exist, they need grandfathering or a heads-up first.
- Orgs near the per-minute/daily send limits will start getting 429s.
- `/tools/email-check` callers above 10/min or 100/hour per IP will start getting 429s.

I have not queried production for affected orgs — that check should gate the merge.

## Verification
- `pnpm typecheck` clean
- `pnpm --filter @wraps/api test` → 138 files / 1147 tests passing, with the guards live. No existing test depended on them being no-ops.
- Lint clean except a pre-existing `useAwait` on `plan-gate.ts:40` (the derive was already `async`); left alone rather than change async semantics on an auth gate for a lint warning.

## Test plan
- [ ] Query production for free-plan orgs with batch activity before merging
- [ ] Confirm the 429 responses carry the intended Retry-After headers in staging
- [ ] Spot-check that authenticated batch sends still work for paid orgs

Found while running /review on #147.