### PR TITLE
fix(selfhost): rename SST config — paths containing ".sst" never receive the aws/sst globals shim

### DIFF
--- a/.github/workflows/selfhost-deploy.yml
+++ b/.github/workflows/selfhost-deploy.yml
@@ -44,7 +44,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
 
       # Upgrades run on a fresh runner with no .env.selfhost on disk.
-      # SST reads config from .env.selfhost (infra/selfhost.sst.config.ts),
+      # SST reads config from .env.selfhost (infra/selfhost.config.ts),
       # so we reconstruct it from repository secrets before deploying.
       # BETTER_AUTH_SECRET / UNSUBSCRIBE_SECRET are the same repository secrets
       # required by the first-time deploy (generate with 'openssl rand -hex 32');

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -280,9 +280,20 @@ jobs:
             [ -f "$f" ] || { echo "::error::$f missing after selfhost:build-deps — the SST esbuild bundle will fail with 'Could not resolve' on customer machines"; exit 1; }
           done
 
+      # SST's bundler injects the aws/sst globals into every source file
+      # EXCEPT paths containing ".sst" (its platform dir check is a naive
+      # substring match). A config named e.g. selfhost.sst.config.ts silently
+      # gets no globals and dies at deploy with "aws is not defined".
+      - name: SST config filename must not contain ".sst"
+        run: |
+          if ls infra/*.ts | grep -q "\.sst"; then
+            echo "::error::An infra config filename contains '.sst' — SST's InjectGlobals plugin skips such paths, so aws/sst globals will be undefined at deploy time"
+            exit 1
+          fi
+
       - name: SST config builds from zero (sst install)
         working-directory: infra
-        run: ../node_modules/.bin/sst install --config selfhost.sst.config.ts --stage production --print-logs
+        run: ../node_modules/.bin/sst install --config selfhost.config.ts --stage production --print-logs
 
       - name: Upgrade script boots and fails with its own guard (not a crash)
         run: |

--- a/apps/website/src/app/docs/guides/self-hosted/page-content.tsx
+++ b/apps/website/src/app/docs/guides/self-hosted/page-content.tsx
@@ -534,7 +534,7 @@ pnpm install`,
             <code className="rounded bg-muted px-1.5 py-0.5">region</code> field
             in{" "}
             <code className="rounded bg-muted px-1.5 py-0.5">
-              infra/selfhost.sst.config.ts
+              infra/selfhost.config.ts
             </code>{" "}
             before deploying.
           </p>
@@ -1139,7 +1139,7 @@ pnpm install`,
                     <td className="py-2">
                       AWS region for deployments (note: must also match{" "}
                       <code className="rounded bg-muted px-1.5 py-0.5">
-                        infra/selfhost.sst.config.ts
+                        infra/selfhost.config.ts
                       </code>
                       )
                     </td>

--- a/infra/selfhost.config.ts
+++ b/infra/selfhost.config.ts
@@ -14,9 +14,18 @@
  * Run via: pnpm selfhost:deploy — sst runs with cwd=infra/, which both the
  * .env.selfhost lookup below and the .sst/platform reference above depend on.
  *
- * Do not import `sst` or `aws` here. SST injects them as globals when it builds
- * this config; importing them from .sst/platform deadlocks `sst install`, which
- * must build the config before it can create that directory.
+ * Two SST sharp edges, both learned the hard way:
+ *
+ * 1. This file's path must NOT contain the substring ".sst". SST's bundler
+ *    injects the `aws`/`sst` import shim into every source file EXCEPT paths
+ *    containing ".sst" (meant to exclude its platform directory) — a name
+ *    like "selfhost.sst.config.ts" matches that check, gets no shim, and
+ *    every `aws.*` reference throws "ReferenceError: aws is not defined" at
+ *    deploy. The selfhost-smoke CI job guards this.
+ *
+ * 2. Do not import `sst` or `aws` here. The injected shim provides them;
+ *    importing them from .sst/platform deadlocks `sst install`, which must
+ *    build the config before that directory exists.
  */
 
 export default $config({

--- a/scripts/selfhost/deploy.ts
+++ b/scripts/selfhost/deploy.ts
@@ -26,7 +26,7 @@ import { REPO_ROOT, runSubprocess } from "./subprocess.js";
 
 const ENV_PATH = join(REPO_ROOT, ".env.selfhost");
 const SST_DIR = join(REPO_ROOT, "infra");
-const SST_CONFIG = "selfhost.sst.config.ts";
+const SST_CONFIG = "selfhost.config.ts";
 const OUTPUTS_PATH = join(REPO_ROOT, "infra", ".sst", "outputs.json");
 
 export type DeployOptions = {
@@ -149,7 +149,7 @@ export async function deploy(options: DeployOptions = {}): Promise<void> {
 
   if (!apiUrl) {
     clack.log.error(
-      "SST deploy did not emit an API URL. Check the selfhost.sst.config.ts outputs."
+      "SST deploy did not emit an API URL. Check the selfhost.config.ts outputs."
     );
     process.exit(1);
   }

--- a/scripts/selfhost/destroy.ts
+++ b/scripts/selfhost/destroy.ts
@@ -12,7 +12,7 @@ import { REPO_ROOT, runSubprocess } from "./subprocess.js";
 
 const ENV_PATH = join(REPO_ROOT, ".env.selfhost");
 const SST_DIR = join(REPO_ROOT, "infra");
-const SST_CONFIG = "selfhost.sst.config.ts";
+const SST_CONFIG = "selfhost.config.ts";
 
 export type DestroyOptions = {
   region?: string;

--- a/scripts/selfhost/upgrade.ts
+++ b/scripts/selfhost/upgrade.ts
@@ -19,7 +19,7 @@ import { REPO_ROOT, runSubprocess } from "./subprocess.js";
 
 const ENV_PATH = join(REPO_ROOT, ".env.selfhost");
 const SST_DIR = join(REPO_ROOT, "infra");
-const SST_CONFIG = "selfhost.sst.config.ts";
+const SST_CONFIG = "selfhost.config.ts";
 const OUTPUTS_PATH = join(REPO_ROOT, "infra", ".sst", "outputs.json");
 
 export type UpgradeOptions = {
@@ -214,7 +214,7 @@ export async function upgrade(options: UpgradeOptions = {}): Promise<void> {
 
   if (!apiUrl) {
     clack.log.error(
-      "SST deploy did not emit an API URL. Check the selfhost.sst.config.ts outputs."
+      "SST deploy did not emit an API URL. Check the selfhost.config.ts outputs."
     );
     process.exit(1);
   }


### PR DESCRIPTION
## Customer-reported failure

Wamy (TB), running `pnpm selfhost:upgrade` from current `main`:

```
ReferenceError: aws is not defined
    at run (…/infra/selfhost.sst.config.ts:47:28)
```

## Root cause — in SST itself

SST's bundler (`pkg/js/js.go`, `InjectGlobals` plugin) prepends the provider shim (`import * as aws from "@pulumi/aws"; import * as sst from "<platform>/src/components";`) to every source file **except paths containing the substring `.sst`** — a check meant to exclude its own platform directory.

Our config was named **`selfhost.sst.config.ts`**. The filename itself matches the check, so the config never received the shim and every bare `aws.*` reference was unbound at `run()` evaluation.

This also explains the repo's history:
- the root `sst.config.ts` works fine daily — its path contains `sst.` but never `.sst`
- the original explicit imports in this file were an accidental workaround for the missing shim — and one of them (`./.sst/platform/src/components/index.js`) is what deadlocked `sst install` on every fresh clone (fixed in `5ae38c3b`, which removed both imports and thereby exposed this)

## Verification

Replicated SST's run-phase esbuild build exactly (same externals, same `InjectGlobals` logic ported from the Go source), against identical file contents under both names:

```
/tmp/selfhost.sst.config.ts  → aws import injected: NO  → ReferenceError: aws is not defined
/tmp/selfhost.config.ts      → aws import injected: YES → works
```

The customer's stack trace matches to the column: `47:28` is the first `new aws.` in `run()`.

## Change

- `git mv infra/selfhost.sst.config.ts infra/selfhost.config.ts`; all references updated (scripts, both workflows, docs)
- config header documents both SST sharp edges (no `.sst` in the filename; no explicit `sst`/`aws` imports)
- new `selfhost-smoke` step fails CI if any `infra/*.ts` filename contains `.sst`, so the class can't ship again

Safe for `app()` evaluation too: SST evaluates `app()` with an empty `Globals` (no shim needed there), and our only `aws` reference in `app()` is a type-only cast that esbuild erases.

## Customer unblock after merge

```
git pull upstream main && pnpm install
pnpm selfhost:upgrade
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XihCjf7hc9TZ7JiETuXptJ