### PR TITLE
fix(email): assume the email role from ambient credentials off Vercel (Sentry #7637247807)

### DIFF
--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -27,6 +27,7 @@
     "@aws-sdk/client-ses": "catalog:",
     "@aws-sdk/client-sesv2": "catalog:",
     "@aws-sdk/client-sts": "catalog:",
+    "@aws-sdk/credential-providers": "catalog:",
     "@react-email/render": "catalog:",
     "@vercel/oidc-aws-credentials-provider": "3.0.4",
     "@wraps.dev/email": "^0.5.1",

--- a/packages/email/src/lib/client.test.ts
+++ b/packages/email/src/lib/client.test.ts
@@ -1,0 +1,130 @@
+import type { SESClient } from "@aws-sdk/client-ses";
+import type { AwsCredentialIdentity } from "@smithy/types";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ROLE_ARN = "arn:aws:iam::010836206701:role/wraps-email-role";
+
+const ASSUMED_CREDENTIALS: AwsCredentialIdentity = {
+  accessKeyId: "ASIAASSUMED",
+  secretAccessKey: "assumed-secret",
+  sessionToken: "assumed-session-token",
+};
+
+const OIDC_CREDENTIALS: AwsCredentialIdentity = {
+  accessKeyId: "ASIAOIDC",
+  secretAccessKey: "oidc-secret",
+  sessionToken: "oidc-session-token",
+};
+
+// Both mocks stand in for AWS credential resolution — the system boundary.
+// Neither is an internal collaborator: they are the only two libraries that
+// exchange an identity for temporary SES-capable credentials.
+const fromTemporaryCredentials = vi.fn(
+  () => () => Promise.resolve(ASSUMED_CREDENTIALS)
+);
+vi.mock("@aws-sdk/credential-providers", () => ({
+  fromTemporaryCredentials: (...args: unknown[]) =>
+    fromTemporaryCredentials(...(args as [])),
+}));
+
+const awsCredentialsProvider = vi.fn(
+  () => () => Promise.resolve(OIDC_CREDENTIALS)
+);
+vi.mock("@vercel/oidc-aws-credentials-provider", () => ({
+  awsCredentialsProvider: (...args: unknown[]) =>
+    awsCredentialsProvider(...(args as [])),
+}));
+
+import { getWrapsClient } from "./client";
+
+/**
+ * Resolve the credentials the returned client would actually sign with.
+ *
+ * `sesClient` is private on WrapsEmail, so reach it by cast. The alternative —
+ * asserting on constructor arguments — would pass for a client that is
+ * configured but cannot resolve credentials, which is exactly the bug here.
+ */
+async function resolveCredentials(
+  wraps: Awaited<ReturnType<typeof getWrapsClient>>
+): Promise<AwsCredentialIdentity> {
+  const ses = (wraps as unknown as { sesClient: SESClient }).sesClient;
+  return await ses.config.credentials();
+}
+
+beforeEach(() => {
+  // Start from an environment that has configured nothing, so each case
+  // controls exactly which signal is present.
+  vi.stubEnv("VERCEL", undefined);
+  vi.stubEnv("AWS_LAMBDA_FUNCTION_NAME", undefined);
+  vi.stubEnv("AWS_WEB_IDENTITY_TOKEN_FILE", undefined);
+  vi.stubEnv("WRAPS_EMAIL_ROLE_ARN", undefined);
+  vi.stubEnv("AWS_ROLE_ARN", undefined);
+  vi.stubEnv("AWS_REGION", "us-east-1");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+});
+
+describe("getWrapsClient", () => {
+  it("assumes the role from ambient credentials on Lambda", async () => {
+    // The event-feed-staleness cron: a Lambda whose execution role is granted
+    // sts:AssumeRole on the dogfood email role. There is no web identity token
+    // file here, so a web-identity-only path throws CredentialsProviderError
+    // ("Web identity configuration not specified") and every alert send dies.
+    vi.stubEnv(
+      "AWS_LAMBDA_FUNCTION_NAME",
+      "wraps-production-EventFeedStaleness"
+    );
+    vi.stubEnv("WRAPS_EMAIL_ROLE_ARN", ROLE_ARN);
+
+    const wraps = await getWrapsClient();
+
+    await expect(resolveCredentials(wraps)).resolves.toEqual(
+      ASSUMED_CREDENTIALS
+    );
+    expect(fromTemporaryCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({ RoleArn: ROLE_ARN }),
+      })
+    );
+  });
+
+  it("uses Vercel OIDC when running on Vercel", async () => {
+    vi.stubEnv("VERCEL", "1");
+    vi.stubEnv("WRAPS_EMAIL_ROLE_ARN", ROLE_ARN);
+
+    const wraps = await getWrapsClient();
+
+    await expect(resolveCredentials(wraps)).resolves.toEqual(OIDC_CREDENTIALS);
+    expect(awsCredentialsProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ roleArn: ROLE_ARN })
+    );
+    expect(fromTemporaryCredentials).not.toHaveBeenCalled();
+  });
+
+  it("leaves the web identity token file to the SDK on EKS and CI", async () => {
+    // EKS and GitHub Actions project a token file and the SDK's own roleArn
+    // branch exchanges it. Assuming from ambient credentials there would fail:
+    // the only identity available is the token itself.
+    vi.stubEnv("AWS_WEB_IDENTITY_TOKEN_FILE", "/var/run/secrets/token");
+    vi.stubEnv("WRAPS_EMAIL_ROLE_ARN", ROLE_ARN);
+
+    await getWrapsClient();
+
+    expect(fromTemporaryCredentials).not.toHaveBeenCalled();
+    expect(awsCredentialsProvider).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the default credential chain with no role configured", async () => {
+    // Local development against a personal profile.
+    const wraps = await getWrapsClient();
+
+    expect(fromTemporaryCredentials).not.toHaveBeenCalled();
+    expect(awsCredentialsProvider).not.toHaveBeenCalled();
+    // The SDK's own chain is installed, not one of ours.
+    const ses = (wraps as unknown as { sesClient: SESClient }).sesClient;
+    expect(ses.config.credentials).toBeTypeOf("function");
+  });
+});

--- a/packages/email/src/lib/client.ts
+++ b/packages/email/src/lib/client.ts
@@ -1,6 +1,9 @@
 import { SESClient } from "@aws-sdk/client-ses";
+import { fromTemporaryCredentials } from "@aws-sdk/credential-providers";
 import { awsCredentialsProvider } from "@vercel/oidc-aws-credentials-provider";
 import { WrapsEmail } from "@wraps.dev/email";
+
+const ROLE_SESSION_NAME = "wraps-email-session";
 
 /**
  * Create SES client for production (Vercel):
@@ -8,13 +11,32 @@ import { WrapsEmail } from "@wraps.dev/email";
  * The dogfood account's wraps-email-role trusts the Vercel OIDC provider
  * via AssumeRoleWithWebIdentity — no intermediary backend role needed.
  */
-function createProductionSESClient(): SESClient {
+function createProductionSESClient(roleArn: string): SESClient {
   const region = process.env.AWS_REGION || "us-east-1";
 
   return new SESClient({
     region,
-    credentials: awsCredentialsProvider({
-      roleArn: process.env.WRAPS_EMAIL_ROLE_ARN!,
+    credentials: awsCredentialsProvider({ roleArn }),
+  });
+}
+
+/**
+ * Create SES client for callers that already hold AWS credentials — a Lambda
+ * execution role, an ECS task role, or a developer's profile — and need to
+ * assume the email role from them via plain sts:AssumeRole.
+ *
+ * The SDK's own `roleArn` option cannot serve these: off Vercel it resolves
+ * credentials with `fromTokenFile`, which requires AWS_WEB_IDENTITY_TOKEN_FILE
+ * and throws "Web identity configuration not specified" without it.
+ */
+function createAssumedRoleSESClient(roleArn: string): SESClient {
+  const region = process.env.AWS_REGION || "us-east-1";
+
+  return new SESClient({
+    region,
+    credentials: fromTemporaryCredentials({
+      params: { RoleArn: roleArn, RoleSessionName: ROLE_SESSION_NAME },
+      clientConfig: { region },
     }),
   });
 }
@@ -22,8 +44,13 @@ function createProductionSESClient(): SESClient {
 /**
  * Get a properly configured WrapsEmail client instance
  *
- * In development: Uses standard AWS credential chain (env vars, profiles, etc.)
- * In production: Uses Vercel OIDC to assume the email role directly
+ * Credentials are chosen by how the caller can prove its identity to STS:
+ *   - Vercel: OIDC web-identity exchange for the email role.
+ *   - A projected web identity token file (EKS, GitHub Actions): the SDK's
+ *     own roleArn path exchanges it.
+ *   - Anything else holding credentials (Lambda, ECS, a dev profile):
+ *     sts:AssumeRole from the ambient chain.
+ *   - No role configured: the standard AWS credential chain.
  *
  * @example
  * ```ts
@@ -34,16 +61,21 @@ function createProductionSESClient(): SESClient {
  */
 export async function getWrapsClient(): Promise<WrapsEmail> {
   const region = process.env.AWS_REGION || "us-east-1";
+  const roleArn = process.env.WRAPS_EMAIL_ROLE_ARN;
 
-  const isProduction =
-    process.env.VERCEL === "1" && process.env.WRAPS_EMAIL_ROLE_ARN;
+  if (!roleArn) {
+    return new WrapsEmail({ region });
+  }
 
-  return isProduction
-    ? new WrapsEmail({ client: createProductionSESClient() })
-    : new WrapsEmail({
-        region,
-        roleArn: process.env.WRAPS_EMAIL_ROLE_ARN,
-      });
+  if (process.env.VERCEL === "1") {
+    return new WrapsEmail({ client: createProductionSESClient(roleArn) });
+  }
+
+  if (process.env.AWS_WEB_IDENTITY_TOKEN_FILE) {
+    return new WrapsEmail({ region, roleArn });
+  }
+
+  return new WrapsEmail({ client: createAssumedRoleSESClient(roleArn) });
 }
 
 export type SendEmailParams = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -701,7 +701,7 @@ importers:
         version: 3.13.0(@tiptap/core@3.13.0(@tiptap/pm@3.13.0))(@tiptap/pm@3.13.0)
       '@vercel/analytics':
         specifier: 1.6.1
-        version: 1.6.1(next@16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 1.6.1(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       '@vercel/blob':
         specifier: 2.0.0
         version: 2.0.0
@@ -710,7 +710,7 @@ importers:
         version: 3.0.4
       '@vercel/speed-insights':
         specifier: 1.3.1
-        version: 1.3.1(next@16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 1.3.1(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       '@wraps.dev/client':
         specifier: 0.7.0
         version: 0.7.0
@@ -806,7 +806,7 @@ importers:
         version: 7.0.1
       nuqs:
         specifier: 2.7.3
-        version: 2.7.3(next@16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router-dom@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.13.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.7.3(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router-dom@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.13.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       pino:
         specifier: 10.1.0
         version: 10.1.0
@@ -1059,10 +1059,10 @@ importers:
         version: 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@vercel/analytics':
         specifier: 1.6.1
-        version: 1.6.1(next@16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 1.6.1(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       '@vercel/speed-insights':
         specifier: 1.3.1
-        version: 1.3.1(next@16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 1.3.1(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       '@wraps.dev/client':
         specifier: 0.2.0
         version: 0.2.0
@@ -1098,7 +1098,7 @@ importers:
         version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       nuqs:
         specifier: 2.7.3
-        version: 2.7.3(next@16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router-dom@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.13.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.7.3(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router-dom@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.13.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       posthog-js:
         specifier: 1.367.0
         version: 1.367.0
@@ -1630,6 +1630,9 @@ importers:
         specifier: 'catalog:'
         version: 3.1091.0
       '@aws-sdk/client-sts':
+        specifier: 'catalog:'
+        version: 3.1074.0
+      '@aws-sdk/credential-providers':
         specifier: 'catalog:'
         version: 3.1074.0
       '@react-email/render':
@@ -2218,10 +2221,6 @@ packages:
 
   '@aws-sdk/credential-provider-ini@3.973.4':
     resolution: {integrity: sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-login@3.972.55':
-    resolution: {integrity: sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.66':
@@ -13636,13 +13635,13 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/types': 3.974.2
       tslib: 2.8.1
 
   '@aws-crypto/crc32c@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/types': 3.974.2
       tslib: 2.8.1
 
   '@aws-crypto/sha1-browser@5.2.0':
@@ -13676,7 +13675,7 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/types': 3.974.2
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -13685,9 +13684,9 @@ snapshots:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/crc32c': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
@@ -13761,12 +13760,12 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/credential-provider-node': 3.972.58
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
-      '@smithy/fetch-http-handler': 5.5.2
-      '@smithy/node-http-handler': 4.8.2
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/credential-provider-node': 3.972.70
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/fetch-http-handler': 5.6.8
+      '@smithy/node-http-handler': 4.9.8
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
@@ -13998,17 +13997,17 @@ snapshots:
 
   '@aws-sdk/credential-provider-cognito-identity@3.972.48':
     dependencies:
-      '@aws-sdk/nested-clients': 3.997.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.49':
     dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
@@ -14022,11 +14021,11 @@ snapshots:
 
   '@aws-sdk/credential-provider-http@3.972.51':
     dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
-      '@smithy/fetch-http-handler': 5.5.2
-      '@smithy/node-http-handler': 4.8.2
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/fetch-http-handler': 5.6.8
+      '@smithy/node-http-handler': 4.9.8
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
@@ -14042,17 +14041,17 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.972.56':
     dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/credential-provider-env': 3.972.49
-      '@aws-sdk/credential-provider-http': 3.972.51
-      '@aws-sdk/credential-provider-login': 3.972.55
-      '@aws-sdk/credential-provider-process': 3.972.49
-      '@aws-sdk/credential-provider-sso': 3.972.55
-      '@aws-sdk/credential-provider-web-identity': 3.972.55
-      '@aws-sdk/nested-clients': 3.997.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
-      '@smithy/credential-provider-imds': 4.4.2
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/credential-provider-env': 3.972.59
+      '@aws-sdk/credential-provider-http': 3.972.61
+      '@aws-sdk/credential-provider-login': 3.972.66
+      '@aws-sdk/credential-provider-process': 3.972.59
+      '@aws-sdk/credential-provider-sso': 3.973.3
+      '@aws-sdk/credential-provider-web-identity': 3.972.65
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/credential-provider-imds': 4.4.11
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
@@ -14069,15 +14068,6 @@ snapshots:
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.6
       '@smithy/credential-provider-imds': 4.4.11
-      '@smithy/types': 4.14.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-login@3.972.55':
-    dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/nested-clients': 3.997.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
@@ -14120,9 +14110,9 @@ snapshots:
 
   '@aws-sdk/credential-provider-process@3.972.49':
     dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
@@ -14136,11 +14126,11 @@ snapshots:
 
   '@aws-sdk/credential-provider-sso@3.972.55':
     dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
       '@aws-sdk/token-providers': 3.1074.0
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
@@ -14175,20 +14165,20 @@ snapshots:
   '@aws-sdk/credential-providers@3.1074.0':
     dependencies:
       '@aws-sdk/client-cognito-identity': 3.1074.0
-      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/core': 3.975.3
       '@aws-sdk/credential-provider-cognito-identity': 3.972.48
-      '@aws-sdk/credential-provider-env': 3.972.49
-      '@aws-sdk/credential-provider-http': 3.972.51
-      '@aws-sdk/credential-provider-ini': 3.972.56
-      '@aws-sdk/credential-provider-login': 3.972.55
-      '@aws-sdk/credential-provider-node': 3.972.58
-      '@aws-sdk/credential-provider-process': 3.972.49
-      '@aws-sdk/credential-provider-sso': 3.972.55
-      '@aws-sdk/credential-provider-web-identity': 3.972.55
-      '@aws-sdk/nested-clients': 3.997.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
-      '@smithy/credential-provider-imds': 4.4.2
+      '@aws-sdk/credential-provider-env': 3.972.59
+      '@aws-sdk/credential-provider-http': 3.972.61
+      '@aws-sdk/credential-provider-ini': 3.973.4
+      '@aws-sdk/credential-provider-login': 3.972.66
+      '@aws-sdk/credential-provider-node': 3.972.70
+      '@aws-sdk/credential-provider-process': 3.972.59
+      '@aws-sdk/credential-provider-sso': 3.973.3
+      '@aws-sdk/credential-provider-web-identity': 3.972.65
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/credential-provider-imds': 4.4.11
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
@@ -14228,7 +14218,7 @@ snapshots:
 
   '@aws-sdk/middleware-sdk-route53@3.972.17':
     dependencies:
-      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/types': 3.974.2
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
@@ -14252,12 +14242,12 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/signature-v4-multi-region': 3.996.35
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
-      '@smithy/fetch-http-handler': 5.5.2
-      '@smithy/node-http-handler': 4.8.2
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/signature-v4-multi-region': 3.996.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/fetch-http-handler': 5.6.8
+      '@smithy/node-http-handler': 4.9.8
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
@@ -14297,10 +14287,10 @@ snapshots:
 
   '@aws-sdk/token-providers@3.1074.0':
     dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/nested-clients': 3.997.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
@@ -19237,7 +19227,7 @@ snapshots:
 
   '@smithy/credential-provider-imds@4.4.2':
     dependencies:
-      '@smithy/core': 3.26.0
+      '@smithy/core': 3.29.6
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
@@ -19278,7 +19268,7 @@ snapshots:
 
   '@smithy/signature-v4@5.5.2':
     dependencies:
-      '@smithy/core': 3.26.0
+      '@smithy/core': 3.29.6
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
@@ -20278,7 +20268,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@1.6.1(next@16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@vercel/analytics@1.6.1(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     optionalDependencies:
       next: 16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
@@ -20300,7 +20290,7 @@ snapshots:
 
   '@vercel/oidc@3.0.5': {}
 
-  '@vercel/speed-insights@1.3.1(next@16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@vercel/speed-insights@1.3.1(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     optionalDependencies:
       next: 16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
@@ -20329,7 +20319,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@27.4.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.22.4)(yaml@2.8.4))
+      vitest: 4.1.9(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@24.10.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@27.4.0)(vite@7.3.2(@types/node@24.10.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.22.4)(yaml@2.8.4))
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -20406,7 +20396,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@27.4.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.22.4)(yaml@2.8.4))
+      vitest: 4.1.9(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@24.10.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@27.4.0)(vite@7.3.2(@types/node@24.10.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.22.4)(yaml@2.8.4))
 
   '@vitest/utils@4.0.18':
     dependencies:
@@ -21948,8 +21938,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.7.0))
@@ -21971,7 +21961,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -21982,22 +21972,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.51.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.51.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.51.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -22008,7 +21998,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.51.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.51.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -24094,7 +24084,7 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuqs@2.7.3(next@16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router-dom@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.13.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
+  nuqs@2.7.3(next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router-dom@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.13.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 19.2.7


### PR DESCRIPTION
## Summary

Auto-detected via Sentry [#7637247807](https://wraps.sentry.io/issues/7637247807/) and [#7637247818](https://wraps.sentry.io/issues/7637247818/) — same error, two fingerprints.

**Root cause.** `getWrapsClient()` passed `roleArn` straight to `@wraps.dev/email`. That SDK's credential resolver (`packages/email/src/utils/credentials.ts` in `wraps-js`) handles exactly two identities: Vercel OIDC, or a projected web identity token file via `fromTokenFile`. A Lambda has neither — it has execution-role credentials in env vars — so `fromTokenFile` threw before any SES call.

`infra/cron.ts:106-119` already grants `EventFeedStaleness` `sts:AssumeRole` on the dogfood email role, and its comment describes assuming the role "from this function's execution role". No code path actually did that.

**Fix.** Pick the credential provider by how the caller can prove identity to STS:

| Environment | Provider |
|---|---|
| Vercel | `awsCredentialsProvider` (OIDC) — unchanged |
| `AWS_WEB_IDENTITY_TOKEN_FILE` set (EKS, GH Actions) | SDK's own `roleArn` path — unchanged |
| Lambda / ECS / dev profile | `fromTemporaryCredentials` — **new** |
| No role configured | default chain — unchanged |

The token-file branch is kept deliberately: on EKS the token *is* the only identity, so assuming from ambient credentials would fail there.

## Sentry context

- Error: `CredentialsProviderError: Web identity configuration not specified`
- Worker: `event-feed-staleness`, stage `alert-owner`
- Occurrences: 4 across both issues, hourly since first deploy of the cron's email path
- Affected users: 0 attributed (server-side cron), but 2 orgs with stale event feeds got no alert

## Blast radius

This is the same alert path as 636b7f94 ("unbreak stale-feed alerts, silent since Jul 7"). That fix unblocked `resolveAppUrl`; the send then failed one step later on credentials. Because `alertOwner` swallows the failure:

- `eventFeedAlertedAt` stayed unset, so the sweep retried hourly forever
- `notifyOrg` is called *after* the send, so affected orgs got **neither** the email nor the in-app notification
- Only the dashboard banner surfaced the stale feed

Self-hosted deployments are also fixed — `infra/selfhost.config.ts:278` passes `WRAPS_EMAIL_ROLE_ARN` to non-Vercel runtimes and hit the same wall.

## Test plan

- [x] Reproduction test added — fails on `main` with the exact production stack (`fromTokenFile` → `coalesceProvider` → `resolvedCredentials`), passes after
- [x] `packages/email` suite: 45/45 pass
- [x] `apps/api` event-feed-staleness suite: 6/6 pass
- [x] `pnpm typecheck`: 25/25 tasks clean
- [x] `pnpm test:baseline`: all 7 ratchets pass
- [ ] Verify in production that the next hourly sweep sets `eventFeedAlertedAt` and the owner email lands

## Notes for review

- New dep `@aws-sdk/credential-providers` on `packages/email`, pinned to the existing workspace catalog version (3.1074.0) already used by `@aws-sdk/client-sts`.
- `pnpm-lock.yaml` churn is mostly incidental: pnpm 10.28.2 normalized stale peer-dependency keys (dropping `@babel/core` from `next`'s peer key, flattening a circular `eslint-import-resolver-typescript` key). The only added importer entry is the one above.
- The upstream SDK is worth fixing too — `@wraps.dev/email` should support plain `sts:AssumeRole` rather than assuming web identity off Vercel. This PR works around it in-repo so the alert path recovers without an npm release.

Generated by sentry-autofix