### PR TITLE
fix(api): alert the customer on an unusable console-access role instead of Sentry (Sentry #7639155000)

### DIFF
--- a/apps/api/src/__tests__/account-health-role-access.test.ts
+++ b/apps/api/src/__tests__/account-health-role-access.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Account Health — broken customer role handling
+ *
+ * A customer whose `wraps-console-access-role` is deleted or whose trust policy
+ * has drifted makes AssumeRole fail with AccessDenied on every hourly sweep.
+ * That is a permanent, customer-actionable condition, not a Wraps defect: it
+ * must reach the customer's inbox (deduped) rather than Sentry, where it
+ * otherwise re-reports forever and nobody is told the account stopped being
+ * health-checked.
+ *
+ * Boundaries mocked: STS/SESv2/CloudWatch (AWS), the database, Sentry, logger.
+ * `getCredentials` runs for real so the classification is exercised against the
+ * error the AWS SDK actually throws.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const ACCOUNT_ROW = {
+  id: "acct-row-1",
+  organizationId: "org-1",
+  name: "Production",
+  accountId: "472506473063",
+  region: "us-east-1",
+  features: { email: { sandbox: false } },
+};
+
+const CREDENTIAL_ROW = {
+  roleArn: "arn:aws:iam::472506473063:role/wraps-console-access-role",
+  externalId: "ext-1",
+  region: "us-east-1",
+};
+
+const mockStsSend = vi.fn();
+const mockSesSend = vi.fn();
+const mockCloudWatchSend = vi.fn();
+
+vi.mock("@aws-sdk/client-sts", () => ({
+  STSClient: class {
+    send = mockStsSend;
+  },
+  AssumeRoleCommand: class {
+    constructor(public input: unknown) {}
+  },
+}));
+
+vi.mock("@aws-sdk/client-sesv2", () => ({
+  SESv2Client: class {
+    send = mockSesSend;
+  },
+  GetAccountCommand: class {
+    constructor(public input: unknown) {}
+  },
+}));
+
+vi.mock("@aws-sdk/client-cloudwatch", () => ({
+  CloudWatchClient: class {
+    send = mockCloudWatchSend;
+  },
+  GetMetricDataCommand: class {
+    constructor(public input: unknown) {}
+  },
+}));
+
+const mockCaptureException = vi.fn();
+vi.mock("@sentry/aws-serverless", () => ({
+  captureException: mockCaptureException,
+  wrapHandler: (handler: unknown) => handler,
+}));
+
+vi.mock("../lib/sentry", () => ({}));
+
+vi.mock("../lib/logger", () => ({
+  log: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  flushLogger: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockNotifyOrg = vi.fn().mockResolvedValue([]);
+const mockHasRecentNotification = vi.fn().mockResolvedValue(false);
+
+vi.mock("@wraps/db", () => {
+  const awsAccountTable = { __table: "awsAccount" };
+  const organizationTable = { __table: "organization" };
+
+  // Route results by target table, and by whether the caller narrows with
+  // .limit() — the sweep awaits where() directly, the single-row reads do not.
+  const chainFor = (table: { __table: string }) => {
+    const rows =
+      table.__table === "organization" ? [{ slug: "acme" }] : [CREDENTIAL_ROW];
+    return {
+      where: () => ({
+        limit: () => Promise.resolve(rows),
+        then: (
+          resolve: (value: unknown) => unknown,
+          reject: (reason: unknown) => unknown
+        ) => Promise.resolve([ACCOUNT_ROW]).then(resolve, reject),
+      }),
+    };
+  };
+
+  return {
+    db: {
+      select: () => ({ from: chainFor }),
+      update: () => ({ set: () => ({ where: () => Promise.resolve([]) }) }),
+    },
+    awsAccount: awsAccountTable,
+    organization: organizationTable,
+    notifyOrg: mockNotifyOrg,
+    hasRecentNotification: mockHasRecentNotification,
+    eq: vi.fn(),
+    and: vi.fn(),
+    isNotNull: vi.fn(),
+  };
+});
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn(),
+  and: vi.fn(),
+  isNotNull: vi.fn(),
+}));
+
+const { handler } = await import("../workers/account-health");
+
+/** Shape of the STS AccessDenied the broken-role accounts actually produce. */
+function accessDeniedError(): Error {
+  const error = new Error(
+    "User: arn:aws:sts::905130073023:assumed-role/wraps-production-AccountHealthHandlerRole/wraps-production-AccountHealthHandlerFunction is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::472506473063:role/wraps-console-access-role"
+  );
+  error.name = "AccessDenied";
+  return error;
+}
+
+const invoke = () =>
+  (handler as (event: unknown, ctx: unknown, cb: unknown) => Promise<unknown>)(
+    {},
+    {},
+    () => {
+      // noop callback — the handler is promise-based
+    }
+  );
+
+describe("account-health with an unusable customer role", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHasRecentNotification.mockResolvedValue(false);
+    mockNotifyOrg.mockResolvedValue([]);
+  });
+
+  it("notifies the organization instead of reporting to Sentry", async () => {
+    mockStsSend.mockRejectedValue(accessDeniedError());
+
+    await invoke();
+
+    expect(mockNotifyOrg).toHaveBeenCalledTimes(1);
+    const payload = mockNotifyOrg.mock.calls[0][0];
+    expect(payload.organizationId).toBe("org-1");
+    expect(payload.type).toBe("aws.role_unreachable");
+    expect(payload.data).toMatchObject({ awsAccountId: "acct-row-1" });
+    // The copy has to name the account and the repair command, or the customer
+    // cannot act on it.
+    expect(`${payload.title} ${payload.body}`).toContain("472506473063");
+    expect(payload.body).toContain("wraps platform update-role");
+
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it("dedupes so an unrepaired role notifies once per window, not hourly", async () => {
+    mockStsSend.mockRejectedValue(accessDeniedError());
+    mockHasRecentNotification.mockResolvedValue(true);
+
+    await invoke();
+
+    expect(mockNotifyOrg).not.toHaveBeenCalled();
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it("still reports unexpected failures to Sentry", async () => {
+    mockStsSend.mockRejectedValue(
+      Object.assign(new TypeError("cannot read property of undefined"), {
+        name: "TypeError",
+      })
+    );
+
+    await invoke();
+
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    expect(mockNotifyOrg).not.toHaveBeenCalled();
+  });
+
+  it("treats a role that lost SES permissions the same as an unusable role", async () => {
+    mockStsSend.mockResolvedValue({
+      Credentials: {
+        AccessKeyId: "AKIA-test",
+        SecretAccessKey: "secret",
+        SessionToken: "token",
+        Expiration: new Date("2099-01-01"),
+      },
+    });
+    const denied = new Error(
+      "User is not authorized to perform: ses:GetAccount"
+    );
+    denied.name = "AccessDeniedException";
+    mockSesSend.mockRejectedValue(denied);
+
+    await invoke();
+
+    expect(mockNotifyOrg).toHaveBeenCalledTimes(1);
+    expect(mockNotifyOrg.mock.calls[0][0].type).toBe("aws.role_unreachable");
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/workers/account-health.ts
+++ b/apps/api/src/workers/account-health.ts
@@ -10,6 +10,8 @@
  *                             (SES review thresholds; pause is 10% / 0.5%)
  *   - ses.quota_warning       >= 80% of the 24h send quota consumed
  *   - ses.production_access   sandbox -> production transition observed
+ *   - aws.role_unreachable    the customer's console-access role cannot be
+ *                             assumed, or no longer grants SES read access
  *
  * Each alert is deduped per account per 24h via hasRecentNotification, so
  * an ongoing episode notifies once per day rather than once per hour.
@@ -24,7 +26,11 @@ import {
   CloudWatchClient,
   GetMetricDataCommand,
 } from "@aws-sdk/client-cloudwatch";
-import { GetAccountCommand, SESv2Client } from "@aws-sdk/client-sesv2";
+import {
+  GetAccountCommand,
+  type GetAccountCommandOutput,
+  SESv2Client,
+} from "@aws-sdk/client-sesv2";
 import { captureException, wrapHandler } from "@sentry/aws-serverless";
 import {
   awsAccount,
@@ -36,12 +42,41 @@ import {
 import type { Handler } from "aws-lambda";
 import { and, eq, isNotNull } from "drizzle-orm";
 import { flushLogger, log } from "../lib/logger";
-import { getCredentials } from "../services/credentials";
+import { type AwsCredentials, getCredentials } from "../services/credentials";
 
 const DEDUPE_WINDOW_MS = 24 * 60 * 60 * 1000; // once per day per account
 const BOUNCE_RATE_WARN = 0.05; // SES review threshold
 const COMPLAINT_RATE_WARN = 0.001; // SES review threshold
 const QUOTA_WARN_RATIO = 0.8;
+
+/**
+ * STS/SES codes that all mean the same thing operationally: the customer's
+ * console-access role is gone, its trust policy no longer admits this Lambda,
+ * or it no longer carries the SES read permissions the sweep needs.
+ */
+const ROLE_ACCESS_ERROR_CODES = [
+  "AccessDenied",
+  "AccessDeniedException",
+  "NoSuchEntity",
+  "NoSuchEntityException",
+  "InvalidClientTokenId",
+  "ExpiredToken",
+  "ExpiredTokenException",
+  "UnrecognizedClientException",
+] as const;
+
+/**
+ * AWS SDK v3 error names are unreliable — some errors arrive as `name: "Error"`
+ * with the real code only in the message — so both are checked.
+ */
+function isRoleAccessError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return ROLE_ACCESS_ERROR_CODES.some(
+    (code) => error.name === code || error.message.includes(code)
+  );
+}
 
 type AccountRow = {
   id: string;
@@ -142,17 +177,42 @@ async function checkAccount(account: AccountRow): Promise<void> {
   }
   const accountHref = `/${orgSlug}/settings/aws-accounts/${account.id}`;
 
-  const credentials = await getCredentials(account.id, account.organizationId);
-  const sesClient = new SESv2Client({
-    region: credentials.region,
-    credentials: {
-      accessKeyId: credentials.accessKeyId,
-      secretAccessKey: credentials.secretAccessKey,
-      sessionToken: credentials.sessionToken,
-    },
-  });
-
-  const info = await sesClient.send(new GetAccountCommand({}));
+  // Assuming the role and reading SES are the two points where a deleted role,
+  // a drifted trust policy, or a stripped inline policy surfaces. That is the
+  // customer's configuration to repair, not a defect here: it never self-heals,
+  // so reporting it to Sentry every hour buries real failures while leaving the
+  // customer unaware their account stopped being health-checked.
+  let credentials: AwsCredentials;
+  let info: GetAccountCommandOutput;
+  try {
+    credentials = await getCredentials(account.id, account.organizationId);
+    info = await new SESv2Client({
+      region: credentials.region,
+      credentials: {
+        accessKeyId: credentials.accessKeyId,
+        secretAccessKey: credentials.secretAccessKey,
+        sessionToken: credentials.sessionToken,
+      },
+    }).send(new GetAccountCommand({}));
+  } catch (error) {
+    if (!isRoleAccessError(error)) {
+      throw error;
+    }
+    await notifyOnce({
+      account,
+      type: "aws.role_unreachable",
+      title: "Wraps can no longer reach your AWS account",
+      body: `The wraps-console-access-role in AWS account ${account.accountId} (${account.region}) cannot be assumed or is missing SES permissions, so health checks — sending paused, reputation, and quota alerts — are not running for this account. Run \`wraps platform update-role\` to repair the role's trust policy and permissions, or \`wraps platform connect\` if the role was deleted.`,
+      href: accountHref,
+      data: { reason: error instanceof Error ? error.name : "unknown" },
+    });
+    log.warn("[account-health] Customer role unusable, skipping account", {
+      accountId: account.id,
+      organizationId: account.organizationId,
+      awsAccountId: account.accountId,
+    });
+    return;
+  }
 
   // 1. Sending paused / enforcement problems — the catastrophic one.
   const enforcement = info.EnforcementStatus;


### PR DESCRIPTION
## Summary

Auto-detected via Sentry issue [#7639155000](https://wraps.sentry.io/issues/7639155000/).

**Root cause.** `account-health` sweeps every connected AWS account hourly (`cron(45 * * * ? *)`), assuming each account's `wraps-console-access-role`. For AWS account `472506473063` that role is either deleted or its trust policy no longer admits the AccountHealth Lambda, so `sts:AssumeRole` fails with `AccessDenied` on every sweep. The handler's per-account `catch` treats this like any other failure and calls `captureException`.

Because the condition is permanent and customer-caused, it never self-heals: **489 events in ~69 hours** — roughly 7/hour, consistent with several `awsAccount` rows (one per region) sharing the one broken role. The worker's own comment already named the second half of the problem:

> Skipped by design so one broken role cannot abort the sweep — which also means an account whose role has drifted stops being health-checked indefinitely without anything surfacing it.

So today this failure mode floods Sentry *and* leaves the customer unaware that their sending-paused, reputation, and quota alerts have stopped running.

**Fix.** Classify role-access failures at the two boundaries where a broken role surfaces — `AssumeRole` and the SES `GetAccount` read — and route them to the customer's inbox as a new `aws.role_unreachable` notification, deduped per account per 24h by the existing `notifyOnce`. The message names the AWS account and the repair command (`wraps platform update-role`, or `wraps platform connect` if the role was deleted). Anything not in that class still throws to the existing Sentry path.

Per `CLAUDE.md`, the classifier checks both `error.name` and `error.message`, since AWS SDK v3 sometimes reports the real code only in the message.

## Sentry context

| | |
|---|---|
| Error | `AccessDenied: ... is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::472506473063:role/wraps-console-access-role` |
| Occurrences | 489 |
| Affected users | 0 (background cron) |
| First seen | 2026-07-29 00:45 UTC |
| Last seen | 2026-07-31 21:48 UTC |

## Test plan

- [x] Reproduction test added — `apps/api/src/__tests__/account-health-role-access.test.ts`, 4 cases: notifies instead of reporting, dedupes to once per window, still reports unexpected errors to Sentry, and treats a role that lost SES permissions the same way. Failed before the fix, passes after.
- [x] Full `@wraps/api` suite passes (150 files, 1290 tests)
- [x] `pnpm --filter @wraps/api typecheck` clean
- [x] `pnpm build` clean
- [x] No new Biome warnings (the 4 on this file pre-exist on `main`)
- [ ] **Human check:** confirm `aws.role_unreachable` renders acceptably in the inbox UI — notification `type` is a free string with no icon/label registry, so this needs eyes rather than a test.
- [ ] **Human check:** this silences a real signal for Wraps. Worth deciding whether an org-wide "N accounts unreachable" view or a Sentry alert at a *count* threshold should replace the per-event noise.

Generated by sentry-autofix