### PR TITLE
fix(web): classify assume-role failures by code, not by error message (Sentry #7708134562)

### DIFF
--- a/apps/web/src/actions/__tests__/aws-accounts.test.ts
+++ b/apps/web/src/actions/__tests__/aws-accounts.test.ts
@@ -10,8 +10,10 @@ import {
   it,
   vi,
 } from "vitest";
+import { AssumeRoleError } from "@/lib/aws/assume-role";
 import {
   deleteAWSAccount,
+  getSMSPhoneNumbers,
   getVerifiedDomains,
   listAWSAccounts,
   removeWebhookSecretAction,
@@ -271,6 +273,9 @@ vi.mock("@/lib/activation-tracking", () => ({
 // Capture warnings so tests can assert on them. `serializeError` stays real —
 // the actions module uses it to shape what gets logged.
 const mockLogWarn = vi.fn();
+// `error` is what forwards to Sentry, so tests assert on it to prove that an
+// expected customer misconfiguration does not page us.
+const mockLogError = vi.fn();
 
 vi.mock("@/lib/logger", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/logger")>();
@@ -279,7 +284,7 @@ vi.mock("@/lib/logger", async (importOriginal) => {
     createActionLogger: () => ({
       info: vi.fn(),
       warn: (...args: unknown[]) => mockLogWarn(...args),
-      error: vi.fn(),
+      error: (...args: unknown[]) => mockLogError(...args),
       debug: vi.fn(),
     }),
   };
@@ -726,6 +731,55 @@ describe("getVerifiedDomains", () => {
       }
     });
 
+    // assumeRole() replaces the underlying AWS message with its own copy, so
+    // the only surviving signal that the customer's role is unusable is the
+    // AssumeRoleError `code`.
+    it.each(["ACCESS_DENIED", "INVALID_TRUST_POLICY"] as const)(
+      "reports a %s assume-role failure as PERMISSION_DENIED",
+      async (code) => {
+        mockLogError.mockClear();
+        mockGetOrAssumeRole.mockRejectedValueOnce(
+          new AssumeRoleError(
+            code,
+            "Wraps could not assume the IAM role. Check that the CloudFormation stack deployed successfully and that the External ID matches the stack output."
+          )
+        );
+
+        const result = await getVerifiedDomains(
+          testAwsAccount.id,
+          testOrganization.id
+        );
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.errorCode).toBe("PERMISSION_DENIED");
+        }
+        // log.error is the Sentry hook — a customer misconfiguration must not page us.
+        expect(mockLogError).not.toHaveBeenCalled();
+      }
+    );
+
+    it("still reports a Wraps-side credential failure as UNKNOWN so it reaches Sentry", async () => {
+      mockLogError.mockClear();
+      mockGetOrAssumeRole.mockRejectedValueOnce(
+        new AssumeRoleError(
+          "INVALID_BACKEND_CREDENTIALS",
+          "Wraps could not authenticate to AWS to validate your connection. This is a Wraps-side issue — please try again shortly."
+        )
+      );
+
+      const result = await getVerifiedDomains(
+        testAwsAccount.id,
+        testOrganization.id
+      );
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.errorCode).toBe("UNKNOWN");
+      }
+      expect(mockLogError).toHaveBeenCalled();
+    });
+
     it("should skip identities that fail to fetch details", async () => {
       mockSend.mockImplementation((command) => {
         if (command._type === "ListEmailIdentitiesCommand") {
@@ -771,6 +825,43 @@ describe("getVerifiedDomains", () => {
         expect(result.identities[0].identity).toBe("good.com");
       }
     });
+  });
+});
+
+describe("getSMSPhoneNumbers", () => {
+  beforeAll(async () => {
+    await db
+      .update(awsAccount)
+      .set({ smsEnabled: true })
+      .where(eq(awsAccount.id, testAwsAccount.id));
+  });
+
+  afterAll(async () => {
+    await db
+      .update(awsAccount)
+      .set({ smsEnabled: false })
+      .where(eq(awsAccount.id, testAwsAccount.id));
+  });
+
+  it("does not page us when the customer's role cannot be assumed", async () => {
+    currentMockUserId = testUser.id;
+    mockLogError.mockClear();
+    mockLogWarn.mockClear();
+    mockGetOrAssumeRole.mockRejectedValueOnce(
+      new AssumeRoleError(
+        "ACCESS_DENIED",
+        "Wraps could not assume the IAM role. Check that the CloudFormation stack deployed successfully and that the External ID matches the stack output."
+      )
+    );
+
+    const result = await getSMSPhoneNumbers(
+      testAwsAccount.id,
+      testOrganization.id
+    );
+
+    expect(result.success).toBe(false);
+    expect(mockLogError).not.toHaveBeenCalled();
+    expect(mockLogWarn).toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/actions/aws-accounts.ts
+++ b/apps/web/src/actions/aws-accounts.ts
@@ -30,7 +30,10 @@ import {
   trackDomainVerified,
 } from "@/lib/activation-tracking";
 import { auditLogEntry, getAuditContext } from "@/lib/audit";
-import { getCredentials } from "@/lib/aws/assume-role";
+import {
+  getCredentials,
+  isCustomerRoleAccessError,
+} from "@/lib/aws/assume-role";
 import { getOrAssumeRole } from "@/lib/aws/credential-cache";
 import { findWrapsArchive } from "@/lib/aws/mailmanager";
 import {
@@ -1551,11 +1554,7 @@ export async function getVerifiedDomains(
       identities: verifiedIdentities,
     };
   } catch (error) {
-    const isAccessDenied =
-      error instanceof Error &&
-      ((error as { name?: string }).name === "AccessDeniedException" ||
-        error.message.includes("is not authorized to perform") ||
-        error.message.includes("Access denied when assuming role"));
+    const isAccessDenied = isCustomerRoleAccessError(error);
 
     if (isAccessDenied) {
       log.warn(
@@ -1689,11 +1688,7 @@ export async function getSMSPhoneNumbers(
       phoneNumbers,
     };
   } catch (error) {
-    const isAccessDenied =
-      error instanceof Error &&
-      ((error as { name?: string }).name === "AccessDeniedException" ||
-        error.message.includes("is not authorized to perform") ||
-        error.message.includes("Access denied when assuming role"));
+    const isAccessDenied = isCustomerRoleAccessError(error);
 
     if (isAccessDenied) {
       log.warn(

--- a/apps/web/src/lib/aws/assume-role.ts
+++ b/apps/web/src/lib/aws/assume-role.ts
@@ -45,6 +45,33 @@ export function classifyAssumeRoleError(error: unknown): AssumeRoleErrorCode {
   return "UNKNOWN";
 }
 
+/**
+ * True when a failure means the customer's IAM role is unusable — a broken
+ * trust policy, a mismatched External ID, or a role missing the permission.
+ * These are customer-side misconfigurations: surface a remediation in the UI
+ * rather than reporting them to Sentry as Wraps defects.
+ *
+ * `assumeRole` replaces the underlying AWS message with its own copy, so the
+ * structured `code` is the only reliable signal for an assume-role failure —
+ * matching on `.message` silently misses every one of them.
+ */
+export function isCustomerRoleAccessError(error: unknown): boolean {
+  if (error instanceof AssumeRoleError) {
+    return (
+      error.code === "ACCESS_DENIED" || error.code === "INVALID_TRUST_POLICY"
+    );
+  }
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  // A call made with successfully assumed credentials still carries the raw
+  // AWS SDK error, where `name` is unreliable and `message` holds the signal.
+  return (
+    error.name === "AccessDeniedException" ||
+    error.message.includes("is not authorized to perform")
+  );
+}
+
 // Types for AWS credentials - compatible with AWS SDK v3
 type AwsCredentialIdentity = {
   accessKeyId: string;


### PR DESCRIPTION
## Summary

Auto-detected via Sentry issue [#7708134562](https://wraps.sentry.io/issues/7708134562/) — `AssumeRoleError` on `POST /propiedata/settings/sender-defaults`.

**Root cause.** `assumeRole()` replaces the underlying AWS message with its own copy and carries the real classification in a structured `code` field. Both `getVerifiedDomains` and `getSMSPhoneNumbers` ignored that field and re-derived "is this access denied?" from `error.name` and three `error.message` substrings — none of which the rewritten message contains. One of the three, `"Access denied when assuming role"`, matches no message anywhere in the repo; it is dead code left over from an earlier version of `assume-role.ts`.

Two consequences, both visible in this issue:

1. The failure reached `log.error`, which is the hook that forwards to Sentry — so a customer's own IAM misconfiguration paged us as a Wraps defect.
2. `getVerifiedDomains` returned `errorCode: "UNKNOWN"`, so the form showed the generic "Failed to load verified domains" toast instead of the actionable "Permission Update Required — run `wraps platform update-role`" branch that already exists. That command's own docstring says it "repairs the trust policy (principal + ExternalId) using stored metadata" — precisely the remediation for this customer.

**Fix.** One exported helper, `isCustomerRoleAccessError`, in `lib/aws/assume-role.ts` alongside the existing `classifyAssumeRoleError`. It branches on `AssumeRoleError.code` for assume-role failures and keeps the raw-SDK name/message check for calls that fail *after* credentials were obtained. Both catch blocks now call it.

`INVALID_BACKEND_CREDENTIALS` deliberately stays `UNKNOWN` — that code means Wraps could not authenticate to AWS, which is ours and should still page us. A test pins that.

## Sentry context

- Error: `AssumeRoleError: Wraps could not assume the IAM role. Check that the CloudFormation stack deployed successfully and that the External ID matches the stack output.`
- Affected users: 1 (org `propiedata`)
- Occurrences: 6
- First seen: 2026-09-02T20:28:26Z
- Environment: vercel-production

Note this PR does not fix the customer's role — it stops us being paged for it and gets them the instruction that does. `propiedata` likely still needs to run `wraps platform update-role`.

## Test plan

- [x] Reproduction tests added — red before the fix with the production error verbatim, green after
- [x] `getVerifiedDomains` returns `PERMISSION_DENIED` and does not call `log.error` for `ACCESS_DENIED` / `INVALID_TRUST_POLICY`
- [x] `INVALID_BACKEND_CREDENTIALS` still returns `UNKNOWN` and still reaches Sentry
- [x] `getSMSPhoneNumbers` warns rather than errors on the same failure
- [x] Full `apps/web` suite: 234 files, 2795 tests passing
- [x] `tsc --noEmit` clean; Biome warning count unchanged from baseline (48 pre-existing on these files, none added)
- [ ] Reviewer: confirm `getSMSPhoneNumbers` should keep its `errorCode`-free result type. Its access-denied branch now classifies correctly but still cannot tell the client, so the phone-number toast stays generic. Left out as scope beyond this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMCCbpYkXhEhtFN8FmP2Vh