### PR TITLE
fix(web): let getSMSPhoneNumbers tell the client the role needs repair

### DIFF
--- a/apps/web/src/actions/__tests__/aws-accounts.test.ts
+++ b/apps/web/src/actions/__tests__/aws-accounts.test.ts
@@ -863,6 +863,46 @@ describe("getSMSPhoneNumbers", () => {
     expect(mockLogError).not.toHaveBeenCalled();
     expect(mockLogWarn).toHaveBeenCalled();
   });
+
+  it("tells the client the role needs repair so the UI can offer a remediation", async () => {
+    currentMockUserId = testUser.id;
+    mockGetOrAssumeRole.mockRejectedValueOnce(
+      new AssumeRoleError(
+        "INVALID_TRUST_POLICY",
+        "Wraps could not assume the IAM role. Check that the CloudFormation stack deployed successfully and that the External ID matches the stack output."
+      )
+    );
+
+    const result = await getSMSPhoneNumbers(
+      testAwsAccount.id,
+      testOrganization.id
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errorCode).toBe("PERMISSION_DENIED");
+    }
+  });
+
+  it("reports a Wraps-side credential failure as UNKNOWN", async () => {
+    currentMockUserId = testUser.id;
+    mockGetOrAssumeRole.mockRejectedValueOnce(
+      new AssumeRoleError(
+        "INVALID_BACKEND_CREDENTIALS",
+        "Wraps could not authenticate to AWS to validate your connection. This is a Wraps-side issue — please try again shortly."
+      )
+    );
+
+    const result = await getSMSPhoneNumbers(
+      testAwsAccount.id,
+      testOrganization.id
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errorCode).toBe("UNKNOWN");
+    }
+  });
 });
 
 describe("listAWSAccounts", () => {

--- a/apps/web/src/actions/aws-accounts.ts
+++ b/apps/web/src/actions/aws-accounts.ts
@@ -1592,6 +1592,7 @@ export type GetSMSPhoneNumbersResult =
   | {
       success: false;
       error: string;
+      errorCode?: "PERMISSION_DENIED" | "UNKNOWN";
     };
 
 /**
@@ -1705,6 +1706,7 @@ export async function getSMSPhoneNumbers(
         error instanceof Error
           ? error.message
           : "Failed to fetch phone numbers",
+      errorCode: isAccessDenied ? "PERMISSION_DENIED" : "UNKNOWN",
     };
   }
 }

--- a/apps/web/src/components/(ee)/workflow-builder/workflow-settings-panel.tsx
+++ b/apps/web/src/components/(ee)/workflow-builder/workflow-settings-panel.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/actions/aws-accounts";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { toastAwsActionError } from "@/lib/aws-permission-toast";
 import { useWorkflowStore } from "./use-workflow-store";
 
 type AwsAccount = {
@@ -159,14 +160,11 @@ export function WorkflowSettingsPanel({
               setFromDomain(firstDomain.identity);
             }
           }
-        } else if (result.errorCode === "PERMISSION_DENIED") {
-          toast.error("Permission Update Required", {
-            description:
-              "Your IAM role needs updated permissions. Run: wraps platform update-role",
-            duration: Number.POSITIVE_INFINITY,
-          });
         } else {
-          toast.error("Failed to load verified domains");
+          toastAwsActionError(
+            result.errorCode,
+            "Failed to load verified domains"
+          );
         }
       } catch {
         toast.error("Failed to load verified domains");
@@ -205,7 +203,7 @@ export function WorkflowSettingsPanel({
             setSenderId(result.phoneNumbers[0].phoneNumber);
           }
         } else {
-          toast.error("Failed to load phone numbers");
+          toastAwsActionError(result.errorCode, "Failed to load phone numbers");
         }
       } catch {
         toast.error("Failed to load phone numbers");

--- a/apps/web/src/components/sender-defaults-form.tsx
+++ b/apps/web/src/components/sender-defaults-form.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/actions/organizations";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { toastAwsActionError } from "@/lib/aws-permission-toast";
 
 type AwsAccount = {
   id: string;
@@ -165,14 +166,11 @@ export function SenderDefaultsForm({
               setCurrentFromDomain(firstDomain.identity);
             }
           }
-        } else if (result.errorCode === "PERMISSION_DENIED") {
-          toast.error("Permission Update Required", {
-            description:
-              "Your IAM role needs updated permissions. Run: wraps platform update-role",
-            duration: Number.POSITIVE_INFINITY,
-          });
         } else {
-          toast.error("Failed to load verified domains");
+          toastAwsActionError(
+            result.errorCode,
+            "Failed to load verified domains"
+          );
         }
       } catch {
         toast.error("Failed to load verified domains");
@@ -213,7 +211,7 @@ export function SenderDefaultsForm({
             form.setFieldValue("senderId", result.phoneNumbers[0].phoneNumber);
           }
         } else {
-          toast.error("Failed to load phone numbers");
+          toastAwsActionError(result.errorCode, "Failed to load phone numbers");
         }
       } catch {
         toast.error("Failed to load phone numbers");

--- a/apps/web/src/lib/aws-permission-toast.ts
+++ b/apps/web/src/lib/aws-permission-toast.ts
@@ -1,0 +1,24 @@
+import { toast } from "sonner";
+
+/**
+ * Surfaces a failed AWS-backed server action.
+ *
+ * `PERMISSION_DENIED` means the customer's IAM role is unusable — a broken
+ * trust policy or a mismatched External ID. `wraps platform update-role`
+ * repairs exactly that, so the toast names it and stays up until dismissed.
+ * Everything else gets the caller's generic message.
+ */
+export function toastAwsActionError(
+  errorCode: "PERMISSION_DENIED" | "UNKNOWN" | undefined,
+  fallbackMessage: string
+): void {
+  if (errorCode === "PERMISSION_DENIED") {
+    toast.error("Permission Update Required", {
+      description:
+        "Your IAM role needs updated permissions. Run: wraps platform update-role",
+      duration: Number.POSITIVE_INFINITY,
+    });
+    return;
+  }
+  toast.error(fallbackMessage);
+}


### PR DESCRIPTION
## Summary

Follow-up to #161, which left this deliberately out of scope.

#161 made `getSMSPhoneNumbers` classify an unusable customer IAM role correctly, but `GetSMSPhoneNumbersResult` had no `errorCode` field — so the correct answer never left the server. Both callers still fell through to the generic `"Failed to load phone numbers"`. A customer whose trust policy is broken got a dead end on the phone-number field while the domain field directly beside it named the exact fix.

- Adds `errorCode?: "PERMISSION_DENIED" | "UNKNOWN"` to the failure variant and returns it.
- Branches on it in both consumers: `sender-defaults-form.tsx` and `workflow-builder/workflow-settings-panel.tsx`.

## On the extracted helper

The `PERMISSION_DENIED` toast was already duplicated once per field per component. Adding the phone-number branch inline would have made a fourth copy and pushed both `fetchPhoneNumbersForAccount` callbacks past Biome's `noExcessiveCognitiveComplexity` ceiling — a new warning in each file.

So this extracts `toastAwsActionError` (`lib/aws-permission-toast.ts`) and routes all four sites through it. That also drops the two pre-existing `fetchDomainsForAccount` warnings back under the ceiling: Biome goes from 4 complexity warnings across these two files to 2, and the two that remain are the untouched component-level ones.

The two domain call sites are behavior-identical — same title, description, and `duration: Number.POSITIVE_INFINITY`. Flagging that this PR touches them, since strictly they were working.

Not touched: `lib/aws/sms-voice.ts` exports a same-named `getSMSPhoneNumbers` with a one-argument signature, used by two API route handlers. Different function, unrelated to this path.

## Test plan

- [x] Reproduction tests added — red first (`expected undefined to be 'PERMISSION_DENIED'`), green after
- [x] `getSMSPhoneNumbers` returns `PERMISSION_DENIED` for `INVALID_TRUST_POLICY`, `UNKNOWN` for `INVALID_BACKEND_CREDENTIALS`
- [x] Full `apps/web` suite: 234 files, 2797 tests passing
- [x] `tsc --noEmit` clean
- [x] Biome: net −2 warnings on the touched components; no new ones
- [ ] Reviewer: the toast copy is duplicated from the domains branch verbatim. If "Run: wraps platform update-role" should differ for the SMS path, this is the place to say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMCCbpYkXhEhtFN8FmP2Vh